### PR TITLE
UX: make project cards fully clickable with explicit source CTA

### DIFF
--- a/html/css/modern.css
+++ b/html/css/modern.css
@@ -2789,12 +2789,18 @@ pre code {
     height: 100%;
     display: flex;
     flex-direction: column;
+    position: relative;
 }
 
 .project-card:hover {
     border-color: var(--color-accent);
     box-shadow: var(--shadow-md);
     transform: translateY(-4px);
+}
+
+.project-card:focus-within {
+    border-color: var(--color-accent);
+    box-shadow: var(--shadow-md);
 }
 
 .project-card .card-title {
@@ -2810,6 +2816,14 @@ pre code {
     font-size: clamp(0.9rem, 1.8vw, 1.0625rem);
     line-height: 1.6;
     color: var(--color-text-secondary);
+}
+
+.project-card-clickable {
+    cursor: pointer;
+}
+
+.project-card-static {
+    opacity: 0.95;
 }
 
 .project-image {
@@ -2841,6 +2855,43 @@ pre code {
     flex-wrap: wrap;
     gap: var(--spacing-xs);
     margin-top: var(--spacing-md);
+}
+
+.project-card-actions {
+    margin-top: auto;
+    padding-top: var(--spacing-md);
+    border-top: 1px solid var(--color-border);
+}
+
+.project-card-link {
+    position: static;
+    color: var(--color-accent);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.project-card-link::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    border-radius: inherit;
+}
+
+.project-card .project-card-cta {
+    position: relative;
+    z-index: 2;
+    display: inline-block;
+}
+
+.project-card-link:focus-visible .project-card-cta,
+.project-card-link:hover .project-card-cta {
+    text-decoration: underline;
+}
+
+.project-card-cta-disabled {
+    color: var(--color-text-secondary);
+    font-weight: 500;
 }
 
 .tech-tag {

--- a/html/js/projects.js
+++ b/html/js/projects.js
@@ -211,12 +211,32 @@ function renderProjectCard(project, containerId) {
     const techTags = tech.length > 0 
         ? tech.map(t => `<span class="tech-tag">${t}</span>`).join('') 
         : '';
+    const repoUrl = typeof project.repo === 'string' ? project.repo.trim() : '';
+    const hasRepoLink = repoUrl.length > 0;
     
     const projectSlug = project.slug || project.name.toLowerCase().replace(/\s+/g, '-');
+    const cardClass = hasRepoLink
+        ? 'project-card fade-in project-card-clickable'
+        : 'project-card fade-in project-card-static';
+    const ctaHtml = hasRepoLink
+        ? `<div class="project-card-actions">
+                <a class="project-card-link stretched-link"
+                   href="${repoUrl}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   data-project-action="repo"
+                   aria-label="View source for ${project.name}">
+                    <span class="project-card-cta" data-translate="projects.viewSource">View Source</span>
+                </a>
+            </div>`
+        : `<div class="project-card-actions">
+                <span class="project-card-cta project-card-cta-disabled"
+                      data-translate="projects.sourceUnavailable">Source Unavailable</span>
+            </div>`;
     
     const cardHtml = `
         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 col-xl-3 mb-4">
-            <div class="project-card fade-in">
+            <div class="${cardClass}" data-project-clickable="${hasRepoLink ? 'true' : 'false'}">
                 <div class="project-header">
                     <img src="${imagePath}" class="project-image" alt="${project.name}" 
                          onerror="this.onerror=null; this.style.display='none';"
@@ -225,6 +245,7 @@ function renderProjectCard(project, containerId) {
                 <h5 class="card-title" data-no-translate="true">${project.name}</h5>
                 <p class="card-text" data-translate="projects.descriptions.${projectSlug}">${summary}</p>
                 ${techTags ? `<div class="project-tech">${techTags}</div>` : ''}
+                ${ctaHtml}
             </div>
         </div>
     `;

--- a/html/js/translations/en.json
+++ b/html/js/translations/en.json
@@ -58,6 +58,8 @@
     "loadError": "Unable to load projects. Please try again later.",
     "fallbackNote": "Showing cached projects; some data may be outdated.",
     "viewGitHub": "View on GitHub →",
+    "viewSource": "View Source",
+    "sourceUnavailable": "Source Unavailable",
     "privateRepo": "Private Repository",
     "privateTooltip": "This repository is private and not publicly accessible",
     "descriptions": {

--- a/html/js/translations/es.json
+++ b/html/js/translations/es.json
@@ -58,6 +58,8 @@
     "loadError": "No se pudieron cargar los proyectos. Por favor, inténtelo de nuevo más tarde.",
     "fallbackNote": "Se muestran proyectos en caché; algunos datos pueden estar desactualizados.",
     "viewGitHub": "Ver en GitHub →",
+    "viewSource": "Ver código fuente",
+    "sourceUnavailable": "Código fuente no disponible",
     "privateRepo": "Repositorio Privado",
     "privateTooltip": "Este repositorio es privado y no es accesible públicamente",
     "descriptions": {

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -186,6 +186,153 @@ test.describe('Projects Page', () => {
     expect(errorVisible).toBeFalsy();
   });
 
+  test('project card has explicit source CTA and stretched click target', async ({ page }) => {
+    const mockProjects = [
+      {
+        name: 'Clickable Card Project',
+        summary: 'Card should be fully clickable with explicit CTA.',
+        status: 'complete',
+        tech: ['TypeScript'],
+        slug: 'clickable-card-project',
+        repo: 'https://github.com/example/clickable-card-project',
+      },
+    ];
+
+    await page.route('**/api/projects**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockProjects),
+      });
+    });
+
+    const browserName = page.context().browser()?.browserType().name() || '';
+    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
+
+    await page.waitForFunction(() => {
+      const c = document.querySelector('#content');
+      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
+    }, { timeout: 15000 });
+
+    const isMobile = await page.evaluate(() => window.innerWidth <= 768);
+    if (isMobile) {
+      await page.locator('#mobile-menu-toggle').click();
+      await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
+      await page.locator('.mobile-nav-item[data-url="html/pages/projects.html"]').click();
+    } else {
+      await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
+    }
+
+    await page.waitForSelector('#content .project-card', { timeout: 15000 });
+
+    const card = page.locator('#content .project-card').first();
+    await expect(card).toHaveAttribute('data-project-clickable', 'true');
+
+    const sourceLink = card.locator('a[data-project-action="repo"]');
+    await expect(sourceLink).toBeVisible();
+    await expect(sourceLink).toHaveAttribute('href', mockProjects[0].repo);
+    await expect(card.locator('.project-card-cta')).toContainText(/View Source/i);
+
+    const popupPromise = page.waitForEvent('popup');
+    await card.locator('.card-text').click();
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(mockProjects[0].repo);
+    await popup.close();
+  });
+
+  test('project card without repo is non-interactive', async ({ page }) => {
+    const mockProjects = [
+      {
+        name: 'No Repo Project',
+        summary: 'Card should not be clickable when repo is missing.',
+        status: 'complete',
+        tech: ['JavaScript'],
+        slug: 'no-repo-project',
+      },
+    ];
+
+    await page.route('**/api/projects**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockProjects),
+      });
+    });
+
+    const browserName = page.context().browser()?.browserType().name() || '';
+    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
+
+    await page.waitForFunction(() => {
+      const c = document.querySelector('#content');
+      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
+    }, { timeout: 15000 });
+
+    const isMobile = await page.evaluate(() => window.innerWidth <= 768);
+    if (isMobile) {
+      await page.locator('#mobile-menu-toggle').click();
+      await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
+      await page.locator('.mobile-nav-item[data-url="html/pages/projects.html"]').click();
+    } else {
+      await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
+    }
+
+    await page.waitForSelector('#content .project-card', { timeout: 15000 });
+
+    const card = page.locator('#content .project-card').first();
+    await expect(card).toHaveAttribute('data-project-clickable', 'false');
+    await expect(card.locator('a[data-project-action="repo"]')).toHaveCount(0);
+    await expect(card.locator('.project-card-cta-disabled')).toContainText(/Source Unavailable/i);
+  });
+
+  test('project source CTA is keyboard focusable and activatable', async ({ page }) => {
+    const mockProjects = [
+      {
+        name: 'Keyboard CTA Project',
+        summary: 'Source link should be keyboard accessible.',
+        status: 'complete',
+        tech: ['Accessibility'],
+        slug: 'keyboard-cta-project',
+        repo: 'https://github.com/example/keyboard-cta-project',
+      },
+    ];
+
+    await page.route('**/api/projects**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(mockProjects),
+      });
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForFunction(() => {
+      const c = document.querySelector('#content');
+      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
+    }, { timeout: 15000 });
+
+    const isMobile = await page.evaluate(() => window.innerWidth <= 768);
+    if (isMobile) {
+      await page.locator('#mobile-menu-toggle').click();
+      await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
+      await page.locator('.mobile-nav-item[data-url="html/pages/projects.html"]').click();
+    } else {
+      await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
+    }
+
+    await page.waitForSelector('#content .project-card a[data-project-action="repo"]', { timeout: 15000 });
+    const sourceLink = page.locator('#content .project-card a[data-project-action="repo"]').first();
+    await sourceLink.focus();
+    await expect(sourceLink).toBeFocused();
+
+    const popupPromise = page.waitForEvent('popup');
+    await page.keyboard.press('Enter');
+    const popup = await popupPromise;
+    await expect(popup).toHaveURL(mockProjects[0].repo);
+    await popup.close();
+  });
+
   test('shows project cards and fallback note when API fails but static fallback succeeds', async ({ page }) => {
     const mockFallbackProjects = [
       { name: 'Fallback Project', summary: 'From static file.', status: 'complete', tech: ['JS'], slug: 'fallback-project', repo: 'https://github.com/example/fallback' },


### PR DESCRIPTION
## Summary
- Make each project card use a stretched-link pattern to the repository when `repo` exists, so users can click anywhere on the card.
- Keep an explicit, labeled CTA inside each card (`View Source`) to preserve clear affordance and accessibility.
- Render a non-interactive card state for projects without a repository link (`Source Unavailable`).

## Implementation details
- Updated project card rendering in `html/js/projects.js` to:
  - emit card-level clickability metadata (`data-project-clickable`),
  - add semantic anchor action (`data-project-action="repo"`) with ARIA label,
  - preserve non-clickable fallback for missing repo URLs.
- Added card interaction styles in `html/css/modern.css`:
  - stretched-link overlay behavior,
  - hover/focus feedback,
  - disabled CTA treatment for non-interactive cards.
- Added translation keys in:
  - `html/js/translations/en.json`
  - `html/js/translations/es.json`

## Tests
Added Playwright coverage in `tests/projects.spec.ts` for:
- explicit source CTA + stretched click target behavior,
- non-interactive behavior when `repo` is missing,
- keyboard focus and Enter activation for source CTA.

## Verification note
- Attempted to run only the new tests locally, but browser launch failed in this environment (`browserType.launch: spawn Unknown system error -86`).
- Please rely on CI for final verification of the new tests.