### PR TITLE
Mermaid in the SPA: render diagrams on /data/projects/ pages (with CI)

### DIFF
--- a/data/projects/mermaid-smoke/index.html
+++ b/data/projects/mermaid-smoke/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mermaid smoke</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="/html/css/modern.css">
+    <link rel="stylesheet" href="/html/css/style.css">
+    <script src="/html/js/mermaid-init.js"></script>
+</head>
+<body>
+    <div class="container">
+        <div class="lesson-content" data-testid="mermaid-smoke-root">
+            <h1 class="section-title" style="font-size:1.25rem;">Mermaid smoke</h1>
+            <p class="text-muted">CI fixture for diagram rendering.</p>
+            <pre class="mermaid">
+flowchart LR
+  A[SPA] --> B[Mermaid]
+  B --> C[SVG]
+            </pre>
+        </div>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            if (typeof window.initMermaidInContent === 'function') {
+                window.initMermaidInContent(document.body);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/html/js/SPAHack.js
+++ b/html/js/SPAHack.js
@@ -246,6 +246,11 @@ $(document).ready(function(){
                             // Re-setup click handlers for newly loaded content
                             setupClickHandlers();
                             window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+                            if (typeof window.initMermaidInContent === 'function' && document.getElementById('content') && document.getElementById('content').querySelector('.mermaid')) {
+                                window.requestAnimationFrame(function () {
+                                    window.initMermaidInContent(document.getElementById('content'));
+                                });
+                            }
                         } else {
                             console.error("Failed to load content from " + sectionUrl);
                         }

--- a/html/js/mermaid-init.js
+++ b/html/js/mermaid-init.js
@@ -1,0 +1,65 @@
+/**
+ * Mermaid: lazy CDN load, theme from data-theme, render .mermaid inside SPA #content or a given root.
+ */
+(function () {
+    var MERMAID_CDN = 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js';
+    var loadPromise = null;
+
+    function loadMermaidIfNeeded() {
+        if (typeof window.mermaid !== 'undefined') {
+            return Promise.resolve();
+        }
+        if (loadPromise) {
+            return loadPromise;
+        }
+        loadPromise = new Promise(function (resolve, reject) {
+            var s = document.createElement('script');
+            s.src = MERMAID_CDN;
+            s.async = true;
+            s.onload = function () {
+                resolve();
+            };
+            s.onerror = function () {
+                loadPromise = null;
+                reject(new Error('Failed to load Mermaid'));
+            };
+            document.head.appendChild(s);
+        });
+        return loadPromise;
+    }
+
+    function getMermaidTheme() {
+        var t = document.documentElement.getAttribute('data-theme');
+        return t === 'dark' ? 'dark' : 'default';
+    }
+
+    /**
+     * @param {ParentNode | Document | null} [root]
+     * @returns {Promise<void>}
+     */
+    window.initMermaidInContent = function initMermaidInContent(root) {
+        root = root || document.getElementById('content') || document.body;
+        if (!root || !root.querySelectorAll) {
+            return Promise.resolve();
+        }
+        var nodes = root.querySelectorAll('.mermaid');
+        if (!nodes.length) {
+            return Promise.resolve();
+        }
+        return loadMermaidIfNeeded()
+            .then(function () {
+                if (typeof window.mermaid === 'undefined') {
+                    return;
+                }
+                window.mermaid.initialize({
+                    startOnLoad: false,
+                    theme: getMermaidTheme(),
+                    securityLevel: 'loose'
+                });
+                return window.mermaid.run({ nodes: nodes });
+            })
+            .catch(function (e) {
+                console.warn('[Mermaid]', e);
+            });
+    };
+})();

--- a/index.html
+++ b/index.html
@@ -462,6 +462,7 @@
             });
         </script>
         <script type="text/javascript" src="html/js/SPAHack.js"></script>
+        <script type="text/javascript" src="html/js/mermaid-init.js"></script>
         <!-- Load API and Projects scripts globally so SPA-loaded pages can use them -->
         <!-- Highlight.js for syntax highlighting -->
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css" id="hljs-theme-light">
@@ -793,6 +794,7 @@
         <main id="content" role="main" tabindex="-1">
             <!-- Load content here -->
         </main>
+        <a href="#" class="inline-load d-none" data-url="/data/projects/mermaid-smoke/index.html" data-testid="mermaid-smoke-spa" aria-hidden="true" tabindex="-1"></a>
         <div class="push8"></div>
 
         <footer id="site-footer" class="site-footer" role="contentinfo">

--- a/tests/mermaid.spec.ts
+++ b/tests/mermaid.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Mermaid diagrams', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('siteLanguage', 'en');
+    });
+  });
+
+  test('renders diagram when smoke fixture is loaded via SPA', async ({ page }) => {
+    const browserName = page.context().browser()?.browserType().name() || '';
+    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    await page.goto('/', {
+      waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
+      timeout: 60_000,
+    });
+
+    await page.waitForFunction(
+      () => {
+        const c = document.querySelector('#content');
+        return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
+      },
+      { timeout: 15_000 }
+    );
+
+    await page.getByTestId('mermaid-smoke-spa').click({ force: true });
+
+    await page.waitForFunction(
+      () => document.querySelector('#content')?.getAttribute('data-content-loaded') === 'true',
+      { timeout: 15_000 }
+    );
+
+    await expect(page.locator('#content svg').first()).toBeVisible({ timeout: 25_000 });
+    await expect(page.getByTestId('mermaid-smoke-root')).toBeVisible();
+  });
+
+  test('renders diagram on full-page load of smoke fixture', async ({ page }) => {
+    await page.goto('/data/projects/mermaid-smoke/index.html', {
+      waitUntil: 'domcontentloaded',
+      timeout: 60_000,
+    });
+
+    await expect(page.locator('[data-testid="mermaid-smoke-root"] svg').first()).toBeVisible({
+      timeout: 25_000,
+    });
+  });
+});


### PR DESCRIPTION
## Why this exists

Docs and tutorials under `/data/projects/` are injected into `#content` by the SPA. Inline `<script>` in those fragments is stripped, so **Mermaid has to run from the shell** after each load.

## What’s in this PR

- **`html/js/mermaid-init.js`** — Lazy-loads Mermaid **11.4.1** from jsDelivr, maps `data-theme` on `<html>` to a Mermaid theme, and exposes `window.initMermaidInContent(root)` for `mermaid.run` on `.mermaid` nodes.
- **`html/js/SPAHack.js`** — After a successful `/data/projects/` fetch (translations + `setupClickHandlers` already applied), calls `initMermaidInContent` when `#content` contains `.mermaid`.
- **Root `index.html`** — Loads `mermaid-init.js` after `SPAHack.js`.
- **Smoke fixture** — `data/projects/mermaid-smoke/index.html` with one trivial diagram plus a small `DOMContentLoaded` path so **full-page** opens still render.
- **Playwright** — `tests/mermaid.spec.ts` covers SPA (hidden `data-testid="mermaid-smoke-spa"` link) and direct navigation to the smoke URL.

## Merge order

This PR is **intentionally first** in a two-step docs effort. A follow-up PR adds the AI engineering automation guide and switches tests to the real Tutorials card (and drops the smoke-only hook).

## How to verify locally

`npx playwright test tests/mermaid.spec.ts`

(Requires Playwright browsers: `npx playwright install` if needed.)