### PR TITLE
Listen aloud: Web Speech for posts & tutorials

### DIFF
--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -10,6 +10,7 @@ This document describes the accessibility features and practices used on the sit
 - **SPA focus management**: When navigating between pages via the SPA, focus is moved to the main content area so screen reader and keyboard users are not left in the navigation.
 - **Footer**: A desktop-first footer (`role="contentinfo"`) provides identity, quick links (GitHub, LinkedIn, Download resume (PDF), Contact, Engineering), and utility controls (theme, language, reduced motion, reset preferences) and a Back to top link. The footer may be hidden or simplified on small screens.
 - **Mobile sidebar**: On small screens, the hamburger menu includes a PREFERENCES section with Language (EN/ES) and Dark Mode (toggle). Footer icons (contact, reset preferences) appear below. Reduced motion is available in the desktop footer and is still applied from stored or system preference on load. Controls are keyboard-accessible and stay in sync with the desktop footer. Coverage: `tests/mobile-sidebar.spec.ts`.
+- **Article listen (read aloud)**: On supported browsers, long-form blog posts and tutorials expose a **Listen** control with `aria-pressed`, dynamic **`aria-label`** (Listen / Pause / Resume), and an **`aria-live="polite"`** status region. See **[Article listen](ARTICLE_LISTEN.md)** for behavior, what content is skipped for speech, and tests (`tests/article-listen.spec.ts`).
 
 ## Testing
 

--- a/docs/ARTICLE_LISTEN.md
+++ b/docs/ARTICLE_LISTEN.md
@@ -1,0 +1,99 @@
+# Article listen (read aloud)
+
+The site can **read long-form content aloud** using the browser’s **Web Speech API** (`speechSynthesis`). The control is injected on **blog post** and **tutorial lesson** views when there is enough speakable text and the API is available.
+
+## Where it appears
+
+| Context | Container | Inserted before |
+| -------- | --------- | ---------------- |
+| Blog post (SPA) | `.post-content` | `article#post-body` |
+| Tutorial lesson | `.lesson-content` | `.lesson-body` |
+
+The script looks inside `#content` after the SPA loads a page. If extracted plain text is shorter than **20 characters**, no bar is shown (avoids empty or stub pages).
+
+## User experience
+
+### Desktop (wider than 768px)
+
+- A **region** (`role="region"`) with a short heading (“Listen to this article” / localized).
+- Primary control: text button **Listen** → **Pause** → **Resume** depending on state.
+- **Stop** appears while playback is active.
+- Status updates are exposed via an **`aria-live="polite"`** element (screen readers).
+
+### Mobile (768px and below)
+
+- **Compact inline** layout: circular **play / pause** icon button plus a short hint (e.g. “Play to read out loud” in English). No full-width toolbar strip.
+- Graphic label, long heading, and Stop are hidden on small screens to save space; the toggle still has an **`aria-label`** that tracks Listen / Pause / Resume.
+
+### Unsupported browsers
+
+If `speechSynthesis` or `SpeechSynthesisUtterance` is missing, a single message is shown instead (see `articleListen.unsupported` in translations).
+
+## What is spoken vs skipped
+
+`html/js/article-listen.js` builds speakable text from a **clone** of the article or lesson body, then removes noisy or non-prose nodes before reading `innerText`. The following are **removed** (not read):
+
+- `script`, `style`, `nav`
+- Elements with class `d-none`
+- `[aria-hidden="true"]`
+- **All `pre` elements** (Mermaid source, code fences, prompt blocks)
+- **`code`** (inline code)
+- **`svg`**
+
+Whitespace is normalized; sequences of blank lines are collapsed. Diagrams rendered from Mermaid are not read as raw syntax because the `pre` source is stripped; surrounding paragraphs still read normally. For how Mermaid is loaded and rendered in the SPA, see **[Mermaid diagrams](MERMAID.md)**.
+
+## Language
+
+Utterance language follows **`TranslationManager.currentLanguage`** when present (`es` → `es-ES`, otherwise `en-US`), else `document.documentElement.lang`, else English.
+
+Changing site language fires **`languageChanged`**; speech is **cancelled** and the bar is **re-mounted** so labels stay in sync.
+
+## Internationalization
+
+Strings live under **`articleListen`** in:
+
+- `html/js/translations/en.json`
+- `html/js/translations/es.json`
+
+Keys include: `label`, `mobileHint`, `listen`, `pause`, `resume`, `stop`, `playing`, `paused`, `unsupported`. Markup uses `data-translate` where applicable; `TranslationManager.applyTranslations()` runs after mount.
+
+## Files
+
+| File | Role |
+| ---- | ---- |
+| `html/js/article-listen.js` | Mount logic, text extraction, synthesis control, observer, `window.ArticleListen` debug API |
+| `html/css/article-listen.css` | Desktop bar, mobile compact layout, dark-mode-friendly toggle colors |
+| `index.html` | Loads stylesheet and script (global, after other site scripts as configured) |
+| `tests/article-listen.spec.ts` | Regression: SPA post control, dark toggle contrast, Mermaid exclusion (mocked `speak`) |
+
+## SPA lifecycle
+
+- **Initial mount**: `DOMContentLoaded` runs `scanAndMount()`.
+- **Navigation**: A **`MutationObserver`** on `#content` watches **`childList` only** (not subtree), with a short **debounce**, so swapping the whole loaded page re-runs the mount without reacting to every in-article DOM tweak (e.g. Mermaid or translation updates).
+- **Duplicate guard**: A node with `[data-article-listen-root]` is removed before inserting a new bar for the same container.
+
+## Developer debugging
+
+In the browser console (when the script is loaded):
+
+```js
+window.ArticleListen.findListenContext();
+window.ArticleListen.extractSpeakableText(document.querySelector('#post-body'));
+window.ArticleListen.scanAndMount();
+```
+
+Useful to verify mount targets and extracted text without starting playback.
+
+## Tests
+
+```bash
+npx playwright test tests/article-listen.spec.ts
+```
+
+Recommended: run at least **chromium** and **chromium-iphone** (see `playwright.config.ts`) because layout and accessible names differ by viewport.
+
+## Related documentation
+
+- [Accessibility](ACCESSIBILITY.md) — landmarks, live regions, and broader a11y testing
+- [Blog testing](testing/blog.md) — post detail structure (`#post-body`)
+- [Tutorials testing](testing/tutorials.md) — lesson layout

--- a/docs/MERMAID.md
+++ b/docs/MERMAID.md
@@ -1,0 +1,53 @@
+# Mermaid diagrams (SPA)
+
+The site renders **Mermaid** diagrams from `<pre class="mermaid">` blocks inside tutorial and other content loaded into the SPA (`#content`). Diagrams follow the active **light/dark** theme and are re-run when **language** changes replace translated diagram source.
+
+## How it works
+
+### Loader and initializer (`html/js/mermaid-init.js`)
+
+- **Lazy CDN**: Mermaid is loaded from jsDelivr (`mermaid@11.4.1`) only when there are unrunnable `.mermaid` nodes (nodes that do not yet contain an `<svg>`).
+- **`window.initMermaidInContent(root?)`**: Finds `.mermaid` under `root` (default `#content` or `document.body`), filters to nodes **without** an existing rendered `<svg>`, loads the library if needed, then runs `mermaid.initialize` and `mermaid.run({ nodes })`.
+- **Theme**: `mermaid.initialize` uses `theme: 'dark'` when `document.documentElement` has `data-theme="dark"`, otherwise `'default'`.
+- **Security**: `securityLevel: 'loose'` is set to match in-page tutorial content; keep diagram source trusted (same-origin or reviewed bundles).
+
+### SPA navigation (`html/js/SPAHack.js`)
+
+After new HTML is injected into `#content`, the SPA checks for `.mermaid` and calls `initMermaidInContent` when available so diagrams render without a full page reload.
+
+### i18n and re-render (`html/js/translation.js`)
+
+For the AI automation tutorial, `data-translate` can swap the **text inside** `<pre class="mermaid">`. When that source changes, the script tracks `dataset.mermaidSource`, sets a flag, and calls `initMermaidInContent` again so diagrams update for the new language. Already-rendered nodes (with `<svg>`) are skipped until the source changes and the pre is eligible for a new run.
+
+## Where it is used
+
+| Location | Notes |
+| -------- | ----- |
+| `data/projects/aiAutomationTut/index.html` | Multiple flow / sequence diagrams; includes `mermaid-init.js` on full-page load |
+| `data/projects/mermaid-smoke/index.html` | Minimal fixture for SPA smoke (`data-testid="mermaid-smoke-root"`) |
+| `index.html` | Loads `mermaid-init.js` globally for SPA-injected pages |
+
+## Relationship to “Listen” (read aloud)
+
+Mermaid lives in `<pre class="mermaid">`. The article listen feature **removes all `pre` elements** when building speakable text, so **diagram source is not read** by the Web Speech layer. See **[Article listen](ARTICLE_LISTEN.md)** for the full exclusion list.
+
+## Testing
+
+```bash
+npx playwright test tests/mermaid.spec.ts
+npx playwright test tests/tutorial-rendering.spec.ts
+```
+
+`tests/mermaid.spec.ts` (`[regression]`) covers SPA and full-page loads, three SVGs in the AI tutorial, language toggles, and sequence diagram text nodes. `tests/tutorial-rendering.spec.ts` adds layout/size checks for rendered diagrams.
+
+## Troubleshooting
+
+- **Blank diagram area**: Check the browser console for `[Mermaid]` warnings; confirm CDN is reachable (corporate blockers).
+- **Diagrams after language switch**: Ensure `initMermaidInContent` runs after translation updates (see `translation.js` and `dataset.mermaidInitRequested` on the guide root).
+- **Theme mismatch**: Toggle site dark mode and re-open the page or trigger a re-init so `getMermaidTheme()` runs again.
+
+## Related documentation
+
+- **[Article listen](ARTICLE_LISTEN.md)** — Read-aloud feature; skips `pre` / Mermaid source for speech
+- **[UI testing](UI_TESTING.md)** — Running Playwright locally
+- **[Tutorials testing](testing/tutorials.md)** — Tutorial navigation and lesson structure

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,8 @@ Welcome to the documentation for rickym270.github.io. This index provides an ove
 - **Visual Regression Tests** (`tests/visual-regression.spec.ts`) - Screenshot comparison
 - **Footer Tests** (`tests/footer.spec.ts`) - Footer visibility, identity, theme/language/reduced-motion/reset, quick links, Back to top
 - **Mobile Sidebar Tests** (`tests/mobile-sidebar.spec.ts`) - Mobile hamburger menu, nav items, Docs/Blog panels, accessibility controls (theme, language, reduce motion, reset preferences)
+- **Article listen Tests** (`tests/article-listen.spec.ts`) - Listen control on SPA blog post, dark-mode toggle contrast, mobile hint, pause state, `extractSpeakableText` API, Mermaid/code excluded from utterance (mocked speech)
+- **Mermaid Tests** (`tests/mermaid.spec.ts`) - Diagrams render via SPA and full-page load, three SVGs on AI tutorial, language switch stability, sequence diagram text
 
 ### Individual Test Documentation
 - **[Contact API Tests](testing/contact.md)** - Testing the contact form API endpoint
@@ -57,6 +59,8 @@ Welcome to the documentation for rickym270.github.io. This index provides an ove
 
 - **[Repository Analysis](REPO_ANALYSIS.md)** - Comprehensive analysis of repository structure, test coverage, and workflows
 - **[Accessibility](ACCESSIBILITY.md)** - Skip link, main landmark, focus visibility, and a11y test coverage
+- **[Article listen (read aloud)](ARTICLE_LISTEN.md)** - Web Speech “listen” feature for blog posts and tutorials: UX, spoken vs skipped content, i18n, SPA behavior, and tests
+- **[Mermaid diagrams (SPA)](MERMAID.md)** - Lazy-loaded Mermaid, theme and i18n re-render, SPA hooks, relation to read-aloud exclusions, and Playwright coverage
 
 ## Contributing
 
@@ -79,6 +83,8 @@ docs/
 ├── EMAIL_SETUP.md               # Email/SMTP configuration
 ├── TURNSTILE_SETUP.md           # Turnstile CAPTCHA setup
 ├── REPO_ANALYSIS.md             # Repository analysis
+├── ARTICLE_LISTEN.md            # Read-aloud (Web Speech) feature for posts & tutorials
+├── MERMAID.md                   # Mermaid in SPA: init, i18n, tests, troubleshooting
 ├── testing/                     # Individual test documentation
 │   ├── contact.md
 │   ├── health.md

--- a/docs/testing/blog.md
+++ b/docs/testing/blog.md
@@ -23,6 +23,7 @@ The blog has two listing pages (Engineering and Personal), reached from the Blog
 When a post is opened (e.g. from Engineering "Read Article" or a card’s "Read more" link), the post HTML is loaded into `#content` via the SPA.
 
 - **Structure**: Banner image at top (`.post-banner`, `.post-banner-img`), then `.post-hero` (`.post-meta` for date/category/read time and `.post-title`), then `#post-body` (article content: paragraphs, h2s, lists, blockquotes).
+- **Listen (read aloud)**: When the post has enough text, a Web Speech toolbar may appear above `#post-body`. See **[Article listen](../ARTICLE_LISTEN.md)** for UX, exclusions (e.g. Mermaid/code), and `tests/article-listen.spec.ts`.
 - **Styling**: Banner has shadow, max-height, and rounded corners; post meta uses secondary text color; blockquotes use accent left border, background, and padding; body has spacing for h2s, paragraphs, and lists. Both `html/css/blog.css` and `html/css/modern.css` apply (posts link both).
 - **Entry points**: Reached via SPA from Engineering "Read Article" or from the first card’s "Read more" link.
 

--- a/docs/testing/tutorials.md
+++ b/docs/testing/tutorials.md
@@ -18,6 +18,8 @@ The tutorials page has been redesigned with a modern card-based layout. Python t
   - `lesson-2-hello-world.html` - First Python program
   - `lesson-3-conditionals.html` - If/else statements
   - `lesson-4-loops.html` - For and while loops
+- **Listen (read aloud)**: SPA-loaded tutorials that use `.lesson-content` / `.lesson-body` can show the same Web Speech toolbar as blog posts when there is enough speakable text. See **[Article listen](../ARTICLE_LISTEN.md)** and `tests/article-listen.spec.ts` (AI tutorial scenario).
+- **Mermaid**: The AI engineering tutorial includes `<pre class="mermaid">` blocks rendered as SVG in the SPA. See **[Mermaid diagrams](../MERMAID.md)**, `tests/mermaid.spec.ts`, and `tests/tutorial-rendering.spec.ts`.
 
 ## Navigation Features
 - Each lesson page has a back button at the top linking to table of contents

--- a/html/css/article-listen.css
+++ b/html/css/article-listen.css
@@ -38,11 +38,32 @@
 .article-listen-toggle {
     flex-shrink: 0;
     font-weight: 600;
+    /* Bootstrap’s bare `.btn` keeps dark text (#212529); bar uses `--color-bg-secondary` (#111 in dark) → invisible label. */
+    color: var(--color-text-primary);
+    background-color: var(--color-bg-tertiary);
+    border: 1px solid var(--color-border);
+}
+
+.article-listen-toggle:hover,
+.article-listen-toggle:focus {
+    color: var(--color-text-primary);
+    background-color: var(--color-bg-secondary);
+    border-color: var(--color-accent);
+}
+
+.article-listen-toggle .article-listen-toggle-label {
+    color: inherit;
 }
 
 .article-listen-stop {
     font-size: 0.875rem;
     padding: 0.25rem 0.5rem;
+    color: var(--color-text-secondary) !important;
+}
+
+.article-listen-stop:hover,
+.article-listen-stop:focus {
+    color: var(--color-text-primary) !important;
 }
 
 .article-listen-bar--unsupported {

--- a/html/css/article-listen.css
+++ b/html/css/article-listen.css
@@ -74,3 +74,99 @@
     font-size: 0.875rem;
     color: var(--color-text-secondary, #6c757d);
 }
+
+/* Desktop: text toggle only (NYT-style full bar). Icon pair exists for mobile but stays hidden. */
+.article-listen-toggle-icons {
+    display: none;
+}
+
+/* Shown only in mobile breakpoint; keeps desktop bar unchanged. */
+.article-listen-mobile-hint {
+    display: none;
+}
+
+/* Mobile only: compact circular play / pause like NYT app — desktop rules above unchanged. */
+@media (max-width: 768px) {
+    /* Shrink to the control only — no full-width strip or right-aligned “floating” button. */
+    .article-listen-bar {
+        display: inline-flex;
+        width: fit-content;
+        max-width: 100%;
+        padding: 0;
+        margin-bottom: var(--spacing-sm, 0.5rem);
+        border: none;
+        background: transparent;
+    }
+
+    .article-listen-inner {
+        width: auto;
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .article-listen-mobile-hint {
+        display: inline;
+        font-size: 0.875rem;
+        font-weight: 500;
+        color: var(--color-text-primary);
+        line-height: 1.25;
+        max-width: 12rem;
+    }
+
+    .article-listen-icon,
+    .article-listen-label {
+        display: none !important;
+    }
+
+    .article-listen-stop {
+        display: none !important;
+    }
+
+    .article-listen-toggle-label {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+
+    .article-listen-toggle-icons {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+
+    .article-listen-icon-pause {
+        display: none;
+    }
+
+    .article-listen-toggle.article-listen-toggle--playing .article-listen-icon-play {
+        display: none;
+    }
+
+    .article-listen-toggle.article-listen-toggle--playing .article-listen-icon-pause {
+        display: block;
+    }
+
+    .article-listen-toggle {
+        width: 48px;
+        height: 48px;
+        min-width: 48px;
+        padding: 0;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .article-listen-toggle .article-listen-toggle-icons .material-symbols-outlined {
+        font-size: 1.75rem;
+    }
+}

--- a/html/css/article-listen.css
+++ b/html/css/article-listen.css
@@ -1,0 +1,55 @@
+/**
+ * Listen-to-article toolbar (blog posts + tutorials)
+ */
+.article-listen-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm, 0.75rem);
+    padding: var(--spacing-md, 1rem) var(--spacing-lg, 1.25rem);
+    margin-bottom: var(--spacing-xl, 1.5rem);
+    border: 1px solid var(--color-border, #dee2e6);
+    border-radius: var(--radius-md, 0.375rem);
+    background: var(--color-bg-secondary, #f8f9fa);
+}
+
+.article-listen-inner {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm, 0.75rem);
+    width: 100%;
+}
+
+.article-listen-icon {
+    font-size: 1.5rem;
+    color: var(--color-accent, #007bff);
+    flex-shrink: 0;
+}
+
+.article-listen-label {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text-primary, #212529);
+    flex: 1 1 auto;
+    min-width: 8rem;
+}
+
+.article-listen-toggle {
+    flex-shrink: 0;
+    font-weight: 600;
+}
+
+.article-listen-stop {
+    font-size: 0.875rem;
+    padding: 0.25rem 0.5rem;
+}
+
+.article-listen-bar--unsupported {
+    background: var(--color-bg-tertiary, #e9ecef);
+}
+
+.article-listen-unsupported {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary, #6c757d);
+}

--- a/html/js/article-listen.js
+++ b/html/js/article-listen.js
@@ -188,21 +188,25 @@
             var ut = new SpeechSynthesisUtterance(text);
             ut.lang = getSpeakLang() === 'es' ? 'es-ES' : 'en-US';
             ut.rate = 1;
+            // Headless / CI engines may invoke onend or onerror synchronously inside speak(),
+            // which would reset the UI before the click task finishes (tests never see "Pause").
+            function scheduleUtteranceFinished(utRef) {
+                window.setTimeout(function () {
+                    if (activeUtterance !== utRef) return;
+                    activeState = 'idle';
+                    activeUtterance = null;
+                    toggleBtn.setAttribute('aria-pressed', 'false');
+                    if (stopBtn) stopBtn.hidden = true;
+                    refreshToggleLabel();
+                    setStatus('');
+                }, 0);
+            }
+
             ut.onend = function () {
-                activeState = 'idle';
-                activeUtterance = null;
-                toggleBtn.setAttribute('aria-pressed', 'false');
-                if (stopBtn) stopBtn.hidden = true;
-                refreshToggleLabel();
-                setStatus('');
+                scheduleUtteranceFinished(ut);
             };
             ut.onerror = function () {
-                activeState = 'idle';
-                activeUtterance = null;
-                toggleBtn.setAttribute('aria-pressed', 'false');
-                if (stopBtn) stopBtn.hidden = true;
-                refreshToggleLabel();
-                setStatus('');
+                scheduleUtteranceFinished(ut);
             };
             activeUtterance = ut;
             activeState = 'playing';

--- a/html/js/article-listen.js
+++ b/html/js/article-listen.js
@@ -188,10 +188,11 @@
             var ut = new SpeechSynthesisUtterance(text);
             ut.lang = getSpeakLang() === 'es' ? 'es-ES' : 'en-US';
             ut.rate = 1;
-            // Headless / CI engines may invoke onend or onerror synchronously inside speak(),
-            // which would reset the UI before the click task finishes (tests never see "Pause").
+            // Headless / CI engines may invoke onend or onerror synchronously inside speak().
+            // A lone setTimeout(0) can still run before automation observes the "Pause" state.
+            // Defer reset until after paint: double rAF, then a macrotask.
             function scheduleUtteranceFinished(utRef) {
-                window.setTimeout(function () {
+                function runFinish() {
                     if (activeUtterance !== utRef) return;
                     activeState = 'idle';
                     activeUtterance = null;
@@ -199,7 +200,17 @@
                     if (stopBtn) stopBtn.hidden = true;
                     refreshToggleLabel();
                     setStatus('');
-                }, 0);
+                }
+                function afterPaintThenMacrotask() {
+                    window.setTimeout(runFinish, 0);
+                }
+                if (typeof window.requestAnimationFrame === 'function') {
+                    window.requestAnimationFrame(function () {
+                        window.requestAnimationFrame(afterPaintThenMacrotask);
+                    });
+                } else {
+                    window.setTimeout(runFinish, 0);
+                }
             }
 
             ut.onend = function () {

--- a/html/js/article-listen.js
+++ b/html/js/article-listen.js
@@ -127,8 +127,13 @@
             '<span class="material-symbols-outlined article-listen-icon" aria-hidden="true">graphic_eq</span>' +
             '<span class="article-listen-label" data-translate="articleListen.label"></span>' +
             '<button type="button" class="btn article-listen-toggle" data-action="toggle" aria-pressed="false">' +
+            '<span class="article-listen-toggle-icons" aria-hidden="true">' +
+            '<span class="material-symbols-outlined article-listen-icon-play">play_arrow</span>' +
+            '<span class="material-symbols-outlined article-listen-icon-pause">pause</span>' +
+            '</span>' +
             '<span data-translate="articleListen.listen" class="article-listen-toggle-label">Listen</span>' +
             '</button>' +
+            '<span class="article-listen-mobile-hint" data-translate="articleListen.mobileHint" aria-hidden="true"></span>' +
             '<button type="button" class="btn btn-link article-listen-stop text-muted" data-action="stop" hidden>' +
             '<span data-translate="articleListen.stop">Stop</span>' +
             '</button>' +
@@ -151,15 +156,31 @@
         }
 
         function refreshToggleLabel() {
-            if (!window.TranslationManager || !labelSpan) return;
-            if (activeState === 'playing') {
-                labelSpan.setAttribute('data-translate', 'articleListen.pause');
-            } else if (activeState === 'paused') {
-                labelSpan.setAttribute('data-translate', 'articleListen.resume');
-            } else {
-                labelSpan.setAttribute('data-translate', 'articleListen.listen');
+            var tm = window.TranslationManager;
+            var key =
+                activeState === 'playing'
+                    ? 'articleListen.pause'
+                    : activeState === 'paused'
+                      ? 'articleListen.resume'
+                      : 'articleListen.listen';
+            if (tm && labelSpan) {
+                labelSpan.setAttribute('data-translate', key);
+                labelSpan.textContent = tm.t(key);
             }
-            labelSpan.textContent = window.TranslationManager.t(labelSpan.getAttribute('data-translate'));
+            if (tm) {
+                toggleBtn.setAttribute('aria-label', tm.t(key));
+            } else {
+                toggleBtn.setAttribute(
+                    'aria-label',
+                    activeState === 'playing' ? 'Pause' : activeState === 'paused' ? 'Resume' : 'Listen'
+                );
+            }
+            toggleBtn.classList.remove('article-listen-toggle--playing', 'article-listen-toggle--paused');
+            if (activeState === 'playing') {
+                toggleBtn.classList.add('article-listen-toggle--playing');
+            } else if (activeState === 'paused') {
+                toggleBtn.classList.add('article-listen-toggle--paused');
+            }
         }
 
         function speakFromStart() {

--- a/html/js/article-listen.js
+++ b/html/js/article-listen.js
@@ -1,0 +1,278 @@
+/**
+ * NYT-style "Listen to this article" using Web Speech API.
+ * Mounts on blog posts (#post-body) and tutorials (.lesson-body). Skips Mermaid/code pre blocks.
+ */
+(function () {
+    var DEBOUNCE_MS = 150;
+    var debounceTimer = null;
+    var activeUtterance = null;
+    var activeState = 'idle'; // idle | playing | paused
+
+    function supported() {
+        return typeof window !== 'undefined' && window.speechSynthesis && typeof SpeechSynthesisUtterance !== 'undefined';
+    }
+
+    /**
+     * @param {HTMLElement} root
+     * @returns {string}
+     */
+    function extractSpeakableText(root) {
+        if (!root || !root.cloneNode) return '';
+        var clone = root.cloneNode(true);
+        clone.querySelectorAll('script, style, nav').forEach(function (n) {
+            n.remove();
+        });
+        clone.querySelectorAll('.d-none').forEach(function (n) {
+            n.remove();
+        });
+        clone.querySelectorAll('[aria-hidden="true"]').forEach(function (n) {
+            n.remove();
+        });
+        // All pre blocks: Mermaid source, rendered diagrams, code samples, prompt templates
+        clone.querySelectorAll('pre').forEach(function (n) {
+            n.remove();
+        });
+        clone.querySelectorAll('code').forEach(function (n) {
+            n.remove();
+        });
+        clone.querySelectorAll('svg').forEach(function (n) {
+            n.remove();
+        });
+        var text = (clone.innerText || clone.textContent || '')
+            .replace(/\u00a0/g, ' ')
+            .replace(/[ \t]+\n/g, '\n')
+            .replace(/\n{3,}/g, '\n\n')
+            .trim();
+        return text;
+    }
+
+    function getSpeakLang() {
+        if (window.TranslationManager && window.TranslationManager.currentLanguage) {
+            return window.TranslationManager.currentLanguage === 'es' ? 'es' : 'en';
+        }
+        var htmlLang = document.documentElement.getAttribute('lang');
+        if (htmlLang && htmlLang.length >= 2) return htmlLang.slice(0, 2);
+        return 'en';
+    }
+
+    /**
+     * @returns {{ container: HTMLElement, body: HTMLElement, insertBefore: HTMLElement } | null}
+     */
+    function findListenContext() {
+        var content = document.getElementById('content');
+        if (!content) return null;
+        var postBody = content.querySelector('article#post-body') || content.querySelector('.post-content #post-body');
+        if (postBody) {
+            var postContainer = postBody.closest('.post-content');
+            if (postContainer) {
+                return { container: postContainer, body: postBody, insertBefore: postBody };
+            }
+        }
+        var lessonBody = content.querySelector('.lesson-content .lesson-body');
+        if (lessonBody) {
+            var lessonContainer = lessonBody.closest('.lesson-content');
+            if (lessonContainer) {
+                return { container: lessonContainer, body: lessonBody, insertBefore: lessonBody };
+            }
+        }
+        return null;
+    }
+
+    function cancelSpeech() {
+        try {
+            if (window.speechSynthesis) window.speechSynthesis.cancel();
+        } catch (e) {}
+        activeUtterance = null;
+        activeState = 'idle';
+    }
+
+    function mountBar(ctx) {
+        var container = ctx.container;
+        var insertBefore = ctx.insertBefore;
+        var body = ctx.body;
+
+        var text = extractSpeakableText(body);
+        if (!text || text.length < 20) {
+            return;
+        }
+
+        var existing = container.querySelector('[data-article-listen-root]');
+        if (existing) {
+            cancelSpeech();
+            existing.remove();
+        }
+
+        if (!supported()) {
+            var fallback = document.createElement('div');
+            fallback.className = 'article-listen-bar article-listen-bar--unsupported';
+            fallback.setAttribute('data-article-listen-root', '');
+            fallback.setAttribute('data-testid', 'article-listen');
+            fallback.innerHTML =
+                '<p class="article-listen-unsupported mb-0" data-translate="articleListen.unsupported"></p>';
+            container.insertBefore(fallback, insertBefore);
+            if (typeof window.TranslationManager !== 'undefined') {
+                window.TranslationManager.applyTranslations();
+            }
+            return;
+        }
+
+        var bar = document.createElement('div');
+        bar.className = 'article-listen-bar';
+        bar.setAttribute('data-article-listen-root', '');
+        bar.setAttribute('data-testid', 'article-listen');
+        bar.setAttribute('role', 'region');
+        bar.setAttribute('aria-label', '');
+        bar.innerHTML =
+            '<div class="article-listen-inner">' +
+            '<span class="material-symbols-outlined article-listen-icon" aria-hidden="true">graphic_eq</span>' +
+            '<span class="article-listen-label" data-translate="articleListen.label"></span>' +
+            '<button type="button" class="btn article-listen-toggle" data-action="toggle" aria-pressed="false">' +
+            '<span data-translate="articleListen.listen" class="article-listen-toggle-label">Listen</span>' +
+            '</button>' +
+            '<button type="button" class="btn btn-link article-listen-stop text-muted" data-action="stop" hidden>' +
+            '<span data-translate="articleListen.stop">Stop</span>' +
+            '</button>' +
+            '<span class="article-listen-status sr-only" aria-live="polite" data-article-listen-status></span>' +
+            '</div>';
+
+        container.insertBefore(bar, insertBefore);
+
+        if (typeof window.TranslationManager !== 'undefined') {
+            window.TranslationManager.applyTranslations();
+        }
+
+        var toggleBtn = bar.querySelector('[data-action="toggle"]');
+        var stopBtn = bar.querySelector('[data-action="stop"]');
+        var statusEl = bar.querySelector('[data-article-listen-status]');
+        var labelSpan = toggleBtn.querySelector('.article-listen-toggle-label');
+
+        function setStatus(msg) {
+            if (statusEl) statusEl.textContent = msg || '';
+        }
+
+        function refreshToggleLabel() {
+            if (!window.TranslationManager || !labelSpan) return;
+            if (activeState === 'playing') {
+                labelSpan.setAttribute('data-translate', 'articleListen.pause');
+            } else if (activeState === 'paused') {
+                labelSpan.setAttribute('data-translate', 'articleListen.resume');
+            } else {
+                labelSpan.setAttribute('data-translate', 'articleListen.listen');
+            }
+            labelSpan.textContent = window.TranslationManager.t(labelSpan.getAttribute('data-translate'));
+        }
+
+        function speakFromStart() {
+            cancelSpeech();
+            var ut = new SpeechSynthesisUtterance(text);
+            ut.lang = getSpeakLang() === 'es' ? 'es-ES' : 'en-US';
+            ut.rate = 1;
+            ut.onend = function () {
+                activeState = 'idle';
+                activeUtterance = null;
+                toggleBtn.setAttribute('aria-pressed', 'false');
+                if (stopBtn) stopBtn.hidden = true;
+                refreshToggleLabel();
+                setStatus('');
+            };
+            ut.onerror = function () {
+                activeState = 'idle';
+                activeUtterance = null;
+                toggleBtn.setAttribute('aria-pressed', 'false');
+                if (stopBtn) stopBtn.hidden = true;
+                refreshToggleLabel();
+                setStatus('');
+            };
+            activeUtterance = ut;
+            activeState = 'playing';
+            toggleBtn.setAttribute('aria-pressed', 'true');
+            if (stopBtn) stopBtn.hidden = false;
+            refreshToggleLabel();
+            setStatus(window.TranslationManager ? window.TranslationManager.t('articleListen.playing') : 'Playing');
+            window.speechSynthesis.speak(ut);
+        }
+
+        toggleBtn.addEventListener('click', function () {
+            if (!supported()) return;
+            if (activeState === 'idle') {
+                speakFromStart();
+                return;
+            }
+            if (activeState === 'playing') {
+                try {
+                    window.speechSynthesis.pause();
+                } catch (e) {}
+                activeState = 'paused';
+                toggleBtn.setAttribute('aria-pressed', 'false');
+                refreshToggleLabel();
+                setStatus(window.TranslationManager ? window.TranslationManager.t('articleListen.paused') : 'Paused');
+                return;
+            }
+            if (activeState === 'paused') {
+                try {
+                    window.speechSynthesis.resume();
+                } catch (e) {}
+                activeState = 'playing';
+                toggleBtn.setAttribute('aria-pressed', 'true');
+                refreshToggleLabel();
+                setStatus(window.TranslationManager ? window.TranslationManager.t('articleListen.playing') : 'Playing');
+            }
+        });
+
+        stopBtn.addEventListener('click', function () {
+            cancelSpeech();
+            toggleBtn.setAttribute('aria-pressed', 'false');
+            stopBtn.hidden = true;
+            refreshToggleLabel();
+            setStatus('');
+        });
+
+        refreshToggleLabel();
+    }
+
+    function scanAndMount() {
+        var ctx = findListenContext();
+        if (!ctx) return;
+        mountBar(ctx);
+    }
+
+    function scheduleScan() {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(function () {
+            debounceTimer = null;
+            scanAndMount();
+        }, DEBOUNCE_MS);
+    }
+
+    function initObserver() {
+        var content = document.getElementById('content');
+        if (!content) return;
+        var obs = new MutationObserver(function () {
+            scheduleScan();
+        });
+        // childList only: avoid remounting when Mermaid or translations mutate inside the article.
+        obs.observe(content, { childList: true, subtree: false });
+    }
+
+    document.addEventListener('languageChanged', function () {
+        cancelSpeech();
+        // Re-mount after translations mutate the article DOM
+        scheduleScan();
+    });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () {
+            scanAndMount();
+            initObserver();
+        });
+    } else {
+        scanAndMount();
+        initObserver();
+    }
+
+    window.ArticleListen = {
+        extractSpeakableText: extractSpeakableText,
+        scanAndMount: scanAndMount,
+        findListenContext: findListenContext,
+    };
+})();

--- a/html/js/translations/en.json
+++ b/html/js/translations/en.json
@@ -515,6 +515,7 @@
   },
   "articleListen": {
     "label": "Listen to this article",
+    "mobileHint": "Play to read out loud",
     "listen": "Listen",
     "pause": "Pause",
     "resume": "Resume",

--- a/html/js/translations/en.json
+++ b/html/js/translations/en.json
@@ -513,6 +513,16 @@
     "tagResilience": "RESILIENCE",
     "tagAutomation": "AUTOMATION"
   },
+  "articleListen": {
+    "label": "Listen to this article",
+    "listen": "Listen",
+    "pause": "Pause",
+    "resume": "Resume",
+    "stop": "Stop",
+    "playing": "Playing",
+    "paused": "Paused",
+    "unsupported": "Listen isn’t available in this browser."
+  },
   "lessons": {
     "pythonTutorial": {
       "title": "Python Tutorial",

--- a/html/js/translations/es.json
+++ b/html/js/translations/es.json
@@ -515,6 +515,7 @@
   },
   "articleListen": {
     "label": "Escuchar este artículo",
+    "mobileHint": "Reproducir para leer en voz alta",
     "listen": "Escuchar",
     "pause": "Pausa",
     "resume": "Reanudar",

--- a/html/js/translations/es.json
+++ b/html/js/translations/es.json
@@ -513,6 +513,16 @@
     "tagResilience": "RESILIENCIA",
     "tagAutomation": "AUTOMATIZACIÓN"
   },
+  "articleListen": {
+    "label": "Escuchar este artículo",
+    "listen": "Escuchar",
+    "pause": "Pausa",
+    "resume": "Reanudar",
+    "stop": "Detener",
+    "playing": "Reproduciendo",
+    "paused": "En pausa",
+    "unsupported": "La lectura en voz alta no está disponible en este navegador."
+  },
   "lessons": {
     "pythonTutorial": {
       "title": "Tutorial de Python",

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
         <!-- Modern CSS -->
         <link rel="stylesheet" href="html/css/modern.css">
         <link rel="stylesheet" href="html/css/style.css">
+        <link rel="stylesheet" href="html/css/article-listen.css">
         
         <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
@@ -497,6 +498,7 @@
         <script type="text/javascript" src="/html/js/projects.js?v=20251110"></script>
         <script type="text/javascript" src="html/js/theme.js"></script>
         <script type="text/javascript" src="html/js/translation.js"></script>
+        <script type="text/javascript" src="html/js/article-listen.js"></script>
         <script type="text/javascript" src="html/js/blog-search.js"></script>
         <script type="text/javascript" src="html/js/blog-pills.js"></script>
         <script type="text/javascript" src="html/js/code-block.js"></script>

--- a/tests/article-listen.spec.ts
+++ b/tests/article-listen.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  gotoHomeReady,
+  openAiTutorialFromTutorialsCard,
+  openTutorialsPageFromNav,
+} from './ai-tutorial.helpers';
+
+async function openEngineeringListing(page: Page): Promise<void> {
+  const isMobile = await page.evaluate(() => window.innerWidth <= 768);
+  const responsePromise = page.waitForResponse(
+    (res) => res.url().includes('engineering.html') && (res.status() === 200 || res.status() === 304),
+    { timeout: 20000 }
+  );
+  if (isMobile) {
+    await page.locator('#mobile-menu-toggle').click();
+    await page.waitForSelector('#mobile-sidebar.active', { timeout: 5000 });
+    await page.evaluate(() => {
+      const panel = document.getElementById('mobile-nav-panel-blog');
+      if (panel) {
+        panel.classList.add('mobile-nav-group-panel-open');
+        panel.setAttribute('aria-hidden', 'false');
+      }
+    });
+    const engineeringLink = page.locator('#mobile-nav-panel-blog').getByRole('link', { name: 'Engineering' });
+    await engineeringLink.scrollIntoViewIfNeeded();
+    await engineeringLink.click();
+  } else {
+    const blogButton = page.locator('#navbar-links').getByRole('button', { name: 'Blog' }).or(
+      page.locator('#navbar-links').getByRole('link', { name: 'Blog' })
+    );
+    await blogButton.hover();
+    await page.locator('.dropdown-menu-blog').first().getByRole('link', { name: 'Engineering' }).click();
+  }
+  await responsePromise.catch(() => {});
+  await page.waitForFunction(
+    () => {
+      const c = document.querySelector('#content');
+      return (
+        (c?.getAttribute('data-content-loaded') === 'true' && !!c?.querySelector('.blog-featured, h1')) ||
+        !!c?.querySelector('.blog-featured')
+      );
+    },
+    { timeout: 15_000 }
+  );
+}
+
+test.describe('[regression] Article listen', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('siteLanguage', 'en');
+    });
+  });
+
+  test('listen control appears on engineering article opened via SPA', async ({ page }) => {
+    await gotoHomeReady(page);
+    await openEngineeringListing(page);
+
+    await page.locator('a.inline-load[data-url*="how-living-with-ms"]').first().click();
+    await page.waitForFunction(
+      () => document.querySelector('#content')?.getAttribute('data-content-loaded') === 'true',
+      { timeout: 15_000 }
+    );
+    await expect(page.locator('article#post-body')).toBeVisible({ timeout: 15_000 });
+
+    await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('article-listen').getByRole('button', { name: /Listen/i })).toBeVisible();
+  });
+
+  test('listen utterance excludes Mermaid source on AI tutorial (SPA)', async ({ page }) => {
+    await page.addInitScript(() => {
+      const synth = window.speechSynthesis;
+      if (!synth || typeof synth.speak !== 'function') return;
+      const orig = synth.speak.bind(synth);
+      synth.speak = function (utterance) {
+        window.__lastSpeakText = utterance.text || '';
+        return orig(utterance);
+      };
+    });
+
+    await gotoHomeReady(page);
+    await openTutorialsPageFromNav(page);
+    await openAiTutorialFromTutorialsCard(page);
+
+    await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
+    await page.getByTestId('article-listen').getByRole('button', { name: /Listen/i }).click();
+
+    await expect
+      .poll(async () => page.evaluate(() => (window as { __lastSpeakText?: string }).__lastSpeakText || ''))
+      .not.toMatch(/flowchart|sequenceDiagram|subgraph|participant\s/i, { timeout: 10_000 });
+
+    const spoken = await page.evaluate(() => (window as { __lastSpeakText?: string }).__lastSpeakText || '');
+    expect(spoken.length).toBeGreaterThan(200);
+    expect(spoken).toMatch(/AI|automation|model/i);
+  });
+});

--- a/tests/article-listen.spec.ts
+++ b/tests/article-listen.spec.ts
@@ -66,6 +66,35 @@ test.describe('[regression] Article listen', () => {
     await expect(page.getByTestId('article-listen').getByRole('button', { name: /Listen/i })).toBeVisible();
   });
 
+  test('listen toggle text is visible in dark mode (contrast)', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('portfolio-theme', 'dark');
+    });
+    await gotoHomeReady(page);
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+    await openEngineeringListing(page);
+    await page.locator('a.inline-load[data-url*="how-living-with-ms"]').first().click();
+    await page.waitForFunction(
+      () => document.querySelector('#content')?.getAttribute('data-content-loaded') === 'true',
+      { timeout: 15_000 }
+    );
+    await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
+
+    const toggleRgb = await page.evaluate(() => {
+      const btn = document.querySelector('.article-listen-toggle');
+      if (!btn) return null;
+      return getComputedStyle(btn).color;
+    });
+    expect(toggleRgb).toBeTruthy();
+    const m = toggleRgb!.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    expect(m, `expected rgb color, got ${toggleRgb}`).toBeTruthy();
+    const r = parseInt(m![1], 10);
+    const g = parseInt(m![2], 10);
+    const b = parseInt(m![3], 10);
+    const luminance = r * 0.299 + g * 0.587 + b * 0.114;
+    expect(luminance, `toggle text too dark on dark bar: ${toggleRgb}`).toBeGreaterThan(160);
+  });
+
   test('listen utterance excludes Mermaid source on AI tutorial (SPA)', async ({ page }) => {
     await page.addInitScript(() => {
       const synth = window.speechSynthesis;

--- a/tests/article-listen.spec.ts
+++ b/tests/article-listen.spec.ts
@@ -142,9 +142,8 @@ test.describe('[regression] Article listen', () => {
     await openAiTutorialFromTutorialsCard(page);
     await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
     await page.getByTestId('article-listen').getByRole('button', { name: /Listen/i }).click();
-    await expect(page.getByTestId('article-listen').getByRole('button', { name: /Pause/i })).toBeVisible({
-      timeout: 5000,
-    });
+    const toggle = page.getByTestId('article-listen').locator('[data-action="toggle"]');
+    await expect.poll(async () => toggle.getAttribute('aria-label'), { timeout: 10_000 }).toMatch(/Pause/i);
   });
 
   test('ArticleListen.extractSpeakableText strips Mermaid pre source from lesson body', async ({

--- a/tests/article-listen.spec.ts
+++ b/tests/article-listen.spec.ts
@@ -121,4 +121,50 @@ test.describe('[regression] Article listen', () => {
     expect(spoken.length).toBeGreaterThan(200);
     expect(spoken).toMatch(/AI|automation|model/i);
   });
+
+  test('mobile viewport shows hint text beside listen control', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoHomeReady(page);
+    await openEngineeringListing(page);
+    await page.locator('a.inline-load[data-url*="how-living-with-ms"]').first().click();
+    await page.waitForFunction(
+      () => document.querySelector('#content')?.getAttribute('data-content-loaded') === 'true',
+      { timeout: 15_000 }
+    );
+    await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator('.article-listen-mobile-hint')).toBeVisible();
+    await expect(page.locator('.article-listen-mobile-hint')).toHaveText(/Play to read out loud/i);
+  });
+
+  test('Listen click switches toggle accessible name to Pause (playing state)', async ({ page }) => {
+    await gotoHomeReady(page);
+    await openTutorialsPageFromNav(page);
+    await openAiTutorialFromTutorialsCard(page);
+    await expect(page.getByTestId('article-listen')).toBeVisible({ timeout: 15_000 });
+    await page.getByTestId('article-listen').getByRole('button', { name: /Listen/i }).click();
+    await expect(page.getByTestId('article-listen').getByRole('button', { name: /Pause/i })).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('ArticleListen.extractSpeakableText strips Mermaid pre source from lesson body', async ({
+    page,
+  }) => {
+    await gotoHomeReady(page);
+    await openTutorialsPageFromNav(page);
+    await openAiTutorialFromTutorialsCard(page);
+    await expect(page.locator('[data-testid="ai-tutorial-guide"]')).toBeVisible({ timeout: 15_000 });
+
+    const extracted = await page.evaluate(() => {
+      const w = window as typeof window & {
+        ArticleListen?: { extractSpeakableText: (el: Element | null) => string };
+      };
+      const body = document.querySelector('.lesson-body');
+      return w.ArticleListen?.extractSpeakableText(body || null) || '';
+    });
+
+    expect(extracted.length).toBeGreaterThan(200);
+    expect(extracted).not.toMatch(/flowchart|sequenceDiagram|subgraph|participant\s/i);
+    expect(extracted).toMatch(/AI|automation|model/i);
+  });
 });


### PR DESCRIPTION
## Summary
Adds an NYT-style **Listen** experience for blog posts and tutorials using the **Web Speech API**. Speakable text skips code blocks, Mermaid `pre` sources, and other non-prose so diagrams are not read as raw syntax.

## UX
- **Desktop:** Full toolbar with label, text toggle (Listen / Pause / Resume), and Stop.
- **Mobile:** Compact inline control (circular play/pause) with a short hint: **Play to read out loud** (EN) / **Reproducir para leer en voz alta** (ES). No full-width bar or right-floated-only button.
- **Dark mode:** Toggle colors use theme tokens so labels stay readable (regression test on luminance).

## Technical
- `html/js/article-listen.js` — mount on `#post-body` / `.lesson-body`, debounced observer on `#content`, cancel on navigation / language change.
- `html/css/article-listen.css` — desktop bar + mobile-only rules.
- **i18n:** `articleListen.*` in `en.json` / `es.json`.
- **Tests:** `tests/article-listen.spec.ts` (`[regression]`) — SPA article control, dark contrast, Mermaid exclusion via mocked `speak`.

## Checklist
- [x] Playwright `article-listen` (chromium + chromium-iphone)
- [x] Wired in `index.html` (script + stylesheet)