### PR TITLE
Make Playwright CI boring again: SPA waits, config tune-up, and doc diagrams

### DIFF
--- a/docs/MERMAID.md
+++ b/docs/MERMAID.md
@@ -23,6 +23,10 @@ For the AI automation tutorial, `data-translate` can swap the **text inside** `<
 
 In `flowchart` / `graph` node text inside `[...]` or `{...}`, an unquoted **`:`** is treated as syntax, which yields **“Syntax error in text”** at render time. Parentheses and other punctuation can also interact badly with the parser depending on context. Prefer **double-quoted labels** whenever the visible text includes a colon, parentheses, slashes you intend as literal text, or other characters that might read as Mermaid syntax, e.g. `A["Artifacts: code, logs, specs"]` instead of `A[Artifacts: code, logs, specs]`, and `B["Step (optional)"]` instead of unquoted `B[Step (optional)]` when in doubt. Apply the same rule after i18n: keep translated diagram strings valid Mermaid. This applies both to SPA `<pre class="mermaid">` sources and to Mermaid fenced blocks in Markdown (for example in [`docs/testing/projects.md`](testing/projects.md)).
 
+### Mermaid in repository Markdown (GitHub)
+
+Fenced blocks with language `mermaid` render on GitHub and in many editors. Use the same quoting rules as above so diagrams in [`docs/UI_TESTING.md`](UI_TESTING.md), post-mortems, and [`docs/testing/README.md`](testing/README.md) stay valid when labels contain colons or parentheses.
+
 ## Where it is used
 
 | Location | Notes |

--- a/docs/Post-Mortem/ci-chromium-iphone-spa-flakiness.md
+++ b/docs/Post-Mortem/ci-chromium-iphone-spa-flakiness.md
@@ -11,6 +11,19 @@ status: "Resolved"
 
 Playwright tests on the **chromium-iphone** project intermittently failed in CI (and sometimes on master after merge) when asserting content after SPA navigation. Failures included: "Post detail page shows banner, hero, and article body" (timeout waiting for `#post-body`), "Read Article button has visible text in dark mode" (timeout waiting for `.blog-featured-cta`), and "projects page matches visual baseline" (0 project cards). The root cause was tests relying on a fixed DOM wait timeout without syncing to the SPA's network request; on chromium-iphone, CI timing is more variable, so the DOM sometimes appeared after the timeout.
 
+```mermaid
+sequenceDiagram
+  participant T as Test
+  participant B as Browser
+  participant S as SPA jQuery load
+  T->>B: waitForResponse fragment URL
+  T->>B: click link
+  B->>S: fetch fragment
+  S-->>B: 200 or 304
+  B-->>T: response optional catch if cache
+  T->>B: waitForFunction DOM ready
+```
+
 ## Impact
 
 - Intermittent CI failures on `chromium-iphone` for blog post-load, blog dark-mode CTA, translation post content, and visual-regression projects page.
@@ -54,5 +67,5 @@ Syncing to the network response removes reliance on a fixed timeout and aligns t
 
 ## Action Items
 
-- [ ] Consider adding a shared SPA navigation helper used by blog, translation, visual-regression, and other specs.
+- [x] Shared helpers in `tests/nav-wait.ts`: `waitForSpaHtmlFragmentResponse`, `gotoHomeReady`, `spaGotoWaitUntil` (used by spa-navigation, navbar, translation `beforeEach`, and others).
 - [ ] Remove any remaining debug-only instrumentation (e.g. `debugLog`) from test files once stability is confirmed.

--- a/docs/Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md
+++ b/docs/Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md
@@ -11,6 +11,13 @@ status: "Resolved"
 
 Firefox tests in CI (e.g. user-journey: theme switching, view documentation, mobile navigation flow) failed with `TimeoutError: page.goto: Timeout 60000ms exceeded` when using `waitUntil: 'networkidle'`. The root cause: in GitHub Actions the page often never reaches "network idle" (ongoing requests, prefetch, or SPA behavior), so the wait never resolves.
 
+```mermaid
+flowchart LR
+  OLD["goto with networkidle on Firefox"] --> HANG["CI may never reach idle"]
+  NEW["spaGotoWaitUntil domcontentloaded"] --> READY["Explicit DOM readiness"]
+  READY --> PASS["Stable assertions"]
+```
+
 ## Impact
 
 - Failures on Firefox in CI (e.g. Playwright Shard 3/5): "complete user journey: theme switching and navigation", "complete user journey: view documentation", "complete user journey: mobile navigation flow".
@@ -43,11 +50,11 @@ Ensures CI passes without changing app behavior. Explicit content waits (e.g. `w
 
 ## Prevention
 
-- For any test that runs in CI with Firefox and does `page.goto('/')` (or similar): prefer `waitUntil: 'domcontentloaded'` and follow with explicit `waitForFunction` / `waitForSelector` for the content under test.
-- Use `networkidle` for Firefox only where CI has been observed to reach idle (e.g. short, isolated tests). If a test times out in CI with "waiting until networkidle", switch that test to `domcontentloaded`.
+- For any test that runs in CI with Firefox and does `page.goto('/')` (or similar): use `spaGotoWaitUntil()` from `tests/nav-wait.ts` and follow with explicit `waitForFunction` / `waitForSelector` for the content under test.
+- Do not use `networkidle` on `page.goto` for this SPA in CI. For optional quiet-network checks after load, use `tryWaitNetworkIdleBounded(page, ms)` from `tests/nav-wait.ts`.
 - Link this post-mortem from [UI_TESTING.md](../UI_TESTING.md) and [testing/README.md](../testing/README.md) so the guideline is discoverable.
 
 ## Action Items
 
 - [x] Link this post-mortem from UI_TESTING.md and testing README.
-- [ ] Consider unifying other Firefox `page.goto` calls to `domcontentloaded` if they start failing in CI (navbar, theme, blog, contact, seo, etc. still use `networkidle` for Firefox).
+- [x] Unified Firefox and other browsers on `spaGotoWaitUntil()` / `domcontentloaded` for `page.goto` across UI specs (see `tests/nav-wait.ts`).

--- a/docs/Post-Mortem/ci-playwright-ui-timeouts.md
+++ b/docs/Post-Mortem/ci-playwright-ui-timeouts.md
@@ -47,6 +47,11 @@ The fixes align tests with the real SPA navigation flow, which removes reliance 
 - Align SEO tests on a shared navigation helper and Firefox-safe wait strategy.
 
 ## Action Items
+
 - Create reusable navigation helpers for SPA tests.
 - Add a lightweight logging utility that always logs to console in CI.
 - Review other visual tests for explicit SPA readiness waits.
+
+## Follow-up (April 2026)
+
+Centralized helpers now live in **`tests/nav-wait.ts`** (`spaGotoWaitUntil`, `gotoHomeReady`, `waitForSpaHtmlFragmentResponse`, `tryWaitNetworkIdleBounded`). **Do not** use Firefox-only `networkidle` on `page.goto` for this SPA in CI; that direction caused hangs (see [CI Firefox page.goto networkidle Timeout](ci-firefox-page-goto-networkidle-timeout.md)). Historical bullets above that recommend `networkidle` on `goto` are superseded for current CI practice.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,13 @@ Welcome to the documentation for rickym270.github.io. This index provides an ove
 
 ## Testing Documentation
 
+```mermaid
+flowchart LR
+  API["API tests Spring Boot port 8080"] --> Guides["TESTING.md"]
+  UI["UI tests Playwright port 4321"] --> UIG["UI_TESTING.md"]
+  UIG --> NW["tests/nav-wait.ts SPA waits"]
+```
+
 ### Main Testing Guides
 - **[API Testing](TESTING.md)** - Complete guide for testing the Spring Boot API
 - **[UI Testing](UI_TESTING.md)** - Complete guide for Playwright E2E tests

--- a/docs/UI_TESTING.md
+++ b/docs/UI_TESTING.md
@@ -89,6 +89,19 @@ There are two GitHub Actions workflows for testing:
 
 Per-job steps (simplified): checkout, setup Node/Java, install deps, (sanity: no browsers; full-suite: install Playwright browsers), build/start API (and UI for full-suite), run tests, upload artifacts (reports, traces, screenshots).
 
+```mermaid
+flowchart TB
+  subgraph pr["Pull request"]
+    S["Sanity job<br/>API GET 200 checks only"]
+    F["Full suite<br/>5 shards in parallel"]
+    S --> M["Merge allowed"]
+    F --> M
+  end
+  subgraph master["Push to master / schedule / dispatch"]
+    FM["Full suite only<br/>when ref is master"]
+  end
+```
+
 ## Test Structure
 
 Tests are located in the `tests/` directory:
@@ -112,14 +125,37 @@ Tests are located in the `tests/` directory:
 
 Configuration is in `playwright.config.ts`:
 
-- **Base URL**: `http://localhost:4321`
-- **Test timeout**: 60 seconds
-- **Expect timeout**: 10 seconds
-- **Web server**: Automatically starts `http-server` on port 4321
+- **Base URL**: `http://127.0.0.1:4321` (avoids `localhost` resolution quirks in CI)
+- **Test timeout**: 45 seconds in CI, 60 seconds locally (per-project overrides exist for mobile)
+- **Expect timeout**: 10 seconds (15 seconds on the `chromium-iphone` project)
+- **Web server**: Playwright can start the static UI server (`scripts/start-web-server-simple.js`) and API (`scripts/start-api-server.sh`) when `PW_MANAGED_WEBSERVER` is not opted out
 - **Browsers**: Chromium, Firefox, Chromium-iPhone (mobile emulation)
-- **Workers**: 2 in CI (reduced from 4 to minimize resource contention and improve test stability)
+- **Workers**: 1 in CI (fewer concurrent browsers + JVM + servers on `ubuntu-latest`); auto locally
+- **Retries**: 1 in CI, 0 locally
 - **Parallel execution**: Enabled within each browser project
 - **Trace**: Enabled on first retry for debugging
+
+### SPA navigation waits (deterministic tests)
+
+Use shared helpers in `tests/nav-wait.ts` so CI does not hang on `networkidle` during `page.goto`, and so fragment navigations align with real network timing on slow profiles (e.g. `chromium-iphone`).
+
+```mermaid
+flowchart LR
+  subgraph initialLoad["Initial load page.goto"]
+    A["spaGotoWaitUntil()<br/>domcontentloaded"]
+    B["waitForFunction / locators<br/>for #content and flags"]
+  end
+  subgraph frag["SPA fragment e.g. Projects"]
+    C["waitForSpaHtmlFragmentResponse()<br/>before click"]
+    D["Click nav link"]
+    E["await response.catch for cache"]
+    F["waitForFunction for DOM"]
+  end
+  A --> B
+  C --> D
+  D --> E
+  E --> F
+```
 
 ## Test Suites
 
@@ -379,6 +415,8 @@ Failed tests automatically capture:
 ### Firefox: page.goto Times Out (networkidle)
 
 If `page.goto` times out in CI with "waiting until networkidle", use `waitUntil: 'domcontentloaded'` and explicit content waits (e.g. `waitForFunction` for `#content` or `data-content-loaded`). See [Post-Mortem: CI Firefox page.goto networkidle Timeout](Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md).
+
+**Rule:** Use `spaGotoWaitUntil()` from `tests/nav-wait.ts` for `page.goto` on this SPA (always `domcontentloaded`). Do not branch on Firefox with `networkidle` on `goto`. After navigation, use explicit readiness (`waitForFunction`, locators) or, for fragment loads, `waitForSpaHtmlFragmentResponse` then DOM (see [Post-Mortem: CI Chromium-iPhone SPA Flakiness](Post-Mortem/ci-chromium-iphone-spa-flakiness.md)). For optional quiet-network checks after load, use `tryWaitNetworkIdleBounded(page, ms)` instead of `goto` + `networkidle`.
 
 ### Translation Tests Fail
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -47,7 +47,7 @@ For comprehensive testing documentation, see:
 
 - **[API Testing Guide](../TESTING.md)** - Complete API testing guide with all endpoints
 - **[UI Testing Guide](../UI_TESTING.md)** - Complete Playwright E2E testing guide
-- For Firefox CI timeouts on `page.goto` with `networkidle`, see [Post-Mortem: CI Firefox page.goto networkidle Timeout](../Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md).
+- For `page.goto` on this SPA, use `spaGotoWaitUntil()` from `tests/nav-wait.ts` (never Firefox-only `networkidle` on `goto`). Background: [Post-Mortem: CI Firefox page.goto networkidle Timeout](../Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md).
 
 ## Test Structure
 
@@ -146,6 +146,15 @@ Playwright tests use a **tiered strategy** so master stays the source of truth (
 Merge is only allowed when sanity and all full-suite shards have passed on the PR, so master is not broken by a merge.
 
 See [UI Testing Guide](../UI_TESTING.md#cicd-integration) for skip keywords and artifact details.
+
+```mermaid
+flowchart LR
+  PR["Open PR"] --> SJ["Sanity job"]
+  PR --> FS["Full suite<br/>5 shards"]
+  SJ --> OK["Both green"]
+  FS --> OK
+  OK --> MERGE["Merge to master"]
+```
 
 ## Need Help?
 

--- a/docs/testing/blog.md
+++ b/docs/testing/blog.md
@@ -22,6 +22,18 @@ The blog has two listing pages (Engineering and Personal), reached from the Blog
 
 When a post is opened (e.g. from Engineering "Read Article" or a card’s "Read more" link), the post HTML is loaded into `#content` via the SPA.
 
+E2E tests should follow **response-then-DOM** (see [CI Chromium-iPhone SPA Flakiness](../Post-Mortem/ci-chromium-iphone-spa-flakiness.md) and `waitForSpaHtmlFragmentResponse` in `tests/nav-wait.ts`):
+
+```mermaid
+sequenceDiagram
+  participant PW as Playwright
+  participant P as Page
+  PW->>P: start waitForResponse post html
+  PW->>P: click Read Article
+  P-->>PW: optional 200 or 304
+  PW->>P: waitForFunction post body in DOM
+```
+
 - **Structure**: Banner image at top (`.post-banner`, `.post-banner-img`), then `.post-hero` (`.post-meta` for date/category/read time and `.post-title`), then `#post-body` (article content: paragraphs, h2s, lists, blockquotes).
 - **Listen (read aloud)**: When the post has enough text, a Web Speech toolbar may appear above `#post-body`. See **[Article listen](../ARTICLE_LISTEN.md)** for UX, exclusions (e.g. Mermaid/code), and `tests/article-listen.spec.ts` (including SPA “back to listing” while playing, which must call `speechSynthesis.cancel`).
 - **Styling**: Banner has shadow, max-height, and rounded corners; post meta uses secondary text color; blockquotes use accent left border, background, and padding; body has spacing for h2s, paragraphs, and lists. Both `html/css/blog.css` and `html/css/modern.css` apply (posts link both).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,13 +7,12 @@ const rootDir = path.dirname(fileURLToPath(import.meta.url));
 // Build config conditionally.
 const config: any = {
   testDir: 'tests',
+  retries: process.env.CI ? 1 : 0,
   timeout: process.env.CI ? 45_000 : 60_000, // Reduce timeout in CI to fail faster and allow more tests to run
   expect: { timeout: 10_000 },
   outputDir: path.join(rootDir, 'test-results'),
-  // Enable parallel test execution within each project
-  // Use 2 workers in CI to avoid resource contention and ensure webServer stability
-  // With 3 browser projects running in parallel, 2 workers per project = 6 concurrent test executions
-  workers: process.env.CI ? 2 : undefined, // 2 workers in CI, auto-detect locally
+  // Single worker in CI reduces browser + webServer contention on ubuntu-latest (see Playwright CI stabilization)
+  workers: process.env.CI ? 1 : undefined,
   fullyParallel: true, // Run all tests in parallel (within each project)
   use: {
     baseURL: 'http://127.0.0.1:4321', // Use 127.0.0.1 instead of localhost for better CI reliability

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Accessibility', () => {
   test.describe.configure({ timeout: 120000 });
@@ -22,8 +23,7 @@ test.describe('Accessibility', () => {
   });
 
   test('page has proper heading hierarchy', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -71,8 +71,7 @@ test.describe('Accessibility', () => {
   });
 
   test('images have alt text', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -114,8 +113,7 @@ test.describe('Accessibility', () => {
   });
 
   test('links have accessible text', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -158,8 +156,7 @@ test.describe('Accessibility', () => {
   });
 
   test('form inputs have labels', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -216,8 +213,7 @@ test.describe('Accessibility', () => {
   });
 
   test('buttons have accessible names', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -245,8 +241,7 @@ test.describe('Accessibility', () => {
   });
 
   test('page has skip to main content link', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check for skip link (common a11y pattern)
@@ -260,8 +255,7 @@ test.describe('Accessibility', () => {
   });
 
   test('color contrast meets WCAG standards', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -290,8 +284,7 @@ test.describe('Accessibility', () => {
   });
 
   test('keyboard navigation works', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -328,8 +321,7 @@ test.describe('Accessibility', () => {
   });
 
   test('ARIA landmarks are present', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists

--- a/tests/ai-tutorial.helpers.ts
+++ b/tests/ai-tutorial.helpers.ts
@@ -1,25 +1,8 @@
 import { expect, type Page } from '@playwright/test';
 
-/**
- * Shared navigation for AI tutorial E2E tests (SPA from home → Tutorials → AI guide).
- */
-export async function gotoHomeReady(page: Page): Promise<void> {
-  const browserName = page.context().browser()?.browserType().name() || '';
-  const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-  await page.goto('/', {
-    waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
-    timeout: 60_000,
-  });
+export { gotoHomeReady, spaGotoWaitUntil } from './nav-wait';
 
-  await page.waitForFunction(
-    () => {
-      const c = document.querySelector('#content');
-      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
-    },
-    { timeout: 15_000 }
-  );
-}
-
+/** Shared navigation for AI tutorial E2E tests (SPA from home → Tutorials → AI guide). */
 export async function openTutorialsPageFromNav(page: Page): Promise<void> {
   const isMobile = await page.evaluate(() => window.innerWidth <= 768);
   if (isMobile) {

--- a/tests/blog.spec.ts
+++ b/tests/blog.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Blog Pages', () => {
   test.describe.configure({ timeout: 120000 });
@@ -10,8 +11,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Engineering page loads via Blog dropdown', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -58,8 +58,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Personal page loads via Blog dropdown', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -97,8 +96,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Engineering page shows Featured Post, Latest Insights, and blog cards', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -154,8 +152,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Personal page shows Coming Soon in Featured and placeholder cards', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -203,8 +200,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Latest Insights search filters cards by query', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -272,8 +268,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Clearing search restores full card grid', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -328,8 +323,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Escape clears search and restores full card grid', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -384,8 +378,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Read Article from Engineering loads post in SPA', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -441,8 +434,7 @@ test.describe('Blog Pages', () => {
   });
 
   test('Post detail page shows banner, hero, and article body', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');

--- a/tests/contact.spec.ts
+++ b/tests/contact.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Contact Page', () => {
-  test.beforeEach(async ({ page, browserName }) => {
+  test.beforeEach(async ({ page }) => {
     // Ensure English is set for these tests
-    // Use networkidle for Firefox, domcontentloaded for others
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    await page.goto('/', { waitUntil, timeout: 90000 });
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil, timeout: 90_000 });
     
     // Wait for TranslationManager to be available and initialized
     await page.waitForFunction(() => {
@@ -331,10 +331,8 @@ test.describe('Contact Page', () => {
       }
     });
     
-    // Use networkidle for Firefox, domcontentloaded for others
-    const browserName = page.context().browser()?.browserType().name() || 'chromium';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    await page.goto('/', { waitUntil, timeout: 90000 });
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil, timeout: 90_000 });
     
     // Wait for initial load
     // Wait for page to be ready - check if content element exists
@@ -461,8 +459,6 @@ test.describe('Contact Page', () => {
       resolveRouteFulfill = resolve;
     });
     
-    // Use networkidle for Firefox, domcontentloaded for others
-    const browserName = page.context().browser()?.browserType().name() || 'chromium';
     // Set up route BEFORE navigation - Playwright routes persist across navigation
     // Use regex pattern for more reliable interception across absolute and relative URLs
     await page.route(/.*\/api\/contact(?:\?.*)?$/, async (route) => {
@@ -510,8 +506,8 @@ test.describe('Contact Page', () => {
     page.on('requestfailed', r => console.log('[requestfailed]', r.method(), r.url(), r.failure()?.errorText));
     page.on('response', r => console.log('[response]', r.status(), r.url()));
 
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    await page.goto('/', { waitUntil, timeout: 90000 });
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil, timeout: 90_000 });
     
     // Wait for initial load
     // Wait for page to be ready - check if content element exists

--- a/tests/docs.spec.ts
+++ b/tests/docs.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Docs/Notes Page', () => {
   test('Notes hero section displays correctly', async ({ page }) => {
@@ -645,11 +646,10 @@ test.describe('Docs/Notes Page', () => {
   });
 
   test('breadcrumbs navigation works correctly', async ({ page }) => {
-    // Firefox needs networkidle instead of default load for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await page.waitForFunction(() => document.querySelector('#content') !== null, { timeout: 15000 });
+
     // Check if we're on mobile
     const isMobile = await page.evaluate(() => window.innerWidth <= 768);
     

--- a/tests/error-handling.spec.ts
+++ b/tests/error-handling.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Error Handling', () => {
   test.describe.configure({ timeout: 120000 });
@@ -28,8 +29,7 @@ test.describe('Error Handling', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -88,8 +88,7 @@ test.describe('Error Handling', () => {
       await route.abort();
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -125,8 +124,7 @@ test.describe('Error Handling', () => {
   });
 
   test('handles invalid form submission', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -212,8 +210,7 @@ test.describe('Error Handling', () => {
       // Navigation failed - verify we can still navigate to home (proves page is functional)
       if (!page.isClosed()) {
         try {
-          const browserName = page.context().browser()?.browserType().name() || '';
-          const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+          const waitUntil = spaGotoWaitUntil();
           await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
           const homeUrl = page.url();
           expect(homeUrl).toBeTruthy();
@@ -238,8 +235,7 @@ test.describe('Error Handling', () => {
       }
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -264,8 +260,7 @@ test.describe('Error Handling', () => {
   });
 
   test('handles missing translation keys gracefully', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -321,8 +316,7 @@ test.describe('Error Handling', () => {
       };
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Page should still load and function

--- a/tests/footer.spec.ts
+++ b/tests/footer.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Site footer', () => {
   test.describe.configure({ timeout: 60000 });
 
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
   });
 
@@ -28,8 +28,7 @@ test.describe('Site footer', () => {
     await page.addInitScript(() => {
       localStorage.setItem('portfolio-theme', 'dark');
     });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     const footerTheme = page.locator('#theme-toggle-footer');
     await expect(footerTheme).toBeVisible();

--- a/tests/home-page.spec.ts
+++ b/tests/home-page.spec.ts
@@ -1,10 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Home page content', () => {
   test('banner image centered with dark background and hero content', async ({ page }) => {
-    // Firefox needs networkidle instead of default 'load' for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     // Ensure Home loaded into #content and banner is visible
     await page.waitForFunction(() => {
@@ -32,8 +31,7 @@ test.describe('Home page content', () => {
   });
 
   test('hero buttons link to LinkedIn and Github correctly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     // Wait for content to load
     await page.waitForFunction(() => {
@@ -48,8 +46,7 @@ test.describe('Home page content', () => {
   });
 
   test('two-column content: left story, right skills', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Wait for content to load
@@ -84,8 +81,7 @@ test.describe('Home page content', () => {
   });
 
   test('hero portrait image is properly displayed', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     const banner = page.locator('#content #homeBanner');
@@ -112,8 +108,7 @@ test.describe('Home page content', () => {
   });
 
   test('View All Skills button has transparent fill and blue outline', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     const viewAllSkillsBtn = page.locator('#content a').filter({ hasText: /View All Skills/i });
@@ -146,8 +141,7 @@ test.describe('Home page content', () => {
   });
 
   test('View All Skills button navigates to skills page via SPA', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Wait for content to load
@@ -237,8 +231,7 @@ test.describe('Home page content', () => {
   });
 
   test('Quick Stats displays last updated in correct format', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Wait for stats section to potentially load
@@ -274,9 +267,7 @@ test.describe('Home page content', () => {
   });
   
   test('Quick Stats cards have centered content and proper text size', async ({ page }) => {
-    // Firefox needs networkidle instead of default 'load' for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'load';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Wait for stats section to load - use proper wait instead of arbitrary timeout

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Home Page Initial Load', () => {
   // Set timeout for all tests in this describe block
@@ -14,8 +15,7 @@ test.describe('Home Page Initial Load', () => {
 
   test('loads Home content on initial load', async ({ page }) => {
     // Use domcontentloaded for faster loads (networkidle is too slow)
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load - give SPA time to initialize
@@ -45,8 +45,7 @@ test.describe('Home Page Initial Load', () => {
     test.setTimeout(90000); // Increase timeout for this test (90 seconds)
     
     // Use domcontentloaded for faster loads
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for home content to load initially
@@ -147,8 +146,7 @@ test.describe('Home Page Initial Load', () => {
   });
 
   test('home page tagline is centered and displays correctly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load
@@ -179,8 +177,7 @@ test.describe('Home Page Initial Load', () => {
   });
 
   test('home page About Me section displays correctly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load
@@ -210,8 +207,7 @@ test.describe('Home Page Initial Load', () => {
   });
 
   test('home page Tech Stack section displays correctly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load
@@ -234,8 +230,7 @@ test.describe('Home Page Initial Load', () => {
   });
 
   test('home page hero buttons are clickable and have correct links', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load

--- a/tests/mobile-sidebar.spec.ts
+++ b/tests/mobile-sidebar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Mobile sidebar', () => {
   test.describe.configure({ timeout: 60000 });
@@ -10,8 +11,7 @@ test.describe('Mobile sidebar', () => {
       localStorage.setItem('siteLanguage', 'en');
     });
     await page.setViewportSize(mobileViewport);
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
   });
 
@@ -63,8 +63,7 @@ test.describe('Mobile sidebar', () => {
       localStorage.setItem('portfolio-reduced-motion', 'true');
     });
     await page.setViewportSize(mobileViewport);
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.locator('#mobile-menu-toggle').click();

--- a/tests/nav-wait.ts
+++ b/tests/nav-wait.ts
@@ -1,0 +1,49 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * `waitUntil` for SPA `page.goto` in Playwright tests.
+ * Do not use `networkidle` for Firefox (or generally) in CI — it often never completes on this SPA
+ * (see docs/Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md).
+ */
+export function spaGotoWaitUntil(): 'domcontentloaded' {
+  return 'domcontentloaded';
+}
+
+/**
+ * Optional bounded quiet-network wait after navigation (e.g. performance specs).
+ * Never blocks indefinitely; ignores timeout/failure.
+ */
+export async function tryWaitNetworkIdleBounded(page: Page, ms: number): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout: ms }).catch(() => {});
+}
+
+/**
+ * Home `/` loaded and SPA #content ready (banner or data-content-loaded).
+ */
+/**
+ * Call before clicking an SPA link that loads an HTML fragment; await the returned promise
+ * (with `.catch(() => {})` if cache may skip the request), then use existing DOM readiness waits.
+ * @see docs/Post-Mortem/ci-chromium-iphone-spa-flakiness.md
+ */
+export function waitForSpaHtmlFragmentResponse(page: Page, urlSubstring: string, timeout = 8000) {
+  return page.waitForResponse(
+    (res) => res.url().includes(urlSubstring) && (res.status() === 200 || res.status() === 304),
+    { timeout }
+  );
+}
+
+export async function gotoHomeReady(page: Page): Promise<void> {
+  const waitUntil = spaGotoWaitUntil();
+  await page.goto('/', {
+    waitUntil,
+    timeout: 60_000,
+  });
+
+  await page.waitForFunction(
+    () => {
+      const c = document.querySelector('#content');
+      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
+    },
+    { timeout: 15_000 }
+  );
+}

--- a/tests/navbar.spec.ts
+++ b/tests/navbar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil, waitForSpaHtmlFragmentResponse } from './nav-wait';
 
 test.describe('Navbar', () => {
   // Set timeout for all tests in this describe block
@@ -13,11 +14,8 @@ test.describe('Navbar', () => {
   });
 
   test('has top navbar with expected links', async ({ page }) => {
-    // Firefox needs networkidle for reliable navigation
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    const timeout = browserName === 'firefox' ? 60000 : 20000;
-    await page.goto('/', { waitUntil, timeout });
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil, timeout: 60_000 });
 
     const nav = page.locator('nav.navbar');
     await expect(nav).toBeVisible();
@@ -90,8 +88,7 @@ test.describe('Navbar', () => {
   });
 
   test('Docs dropdown arrow is on same line as text', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Skip on mobile - navbar links are hidden
@@ -118,14 +115,14 @@ test.describe('Navbar', () => {
   });
 
   test('Home link loads home page content', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile - navbar links are hidden on mobile
     const isMobile = await page.evaluate(() => window.innerWidth <= 768);
     
     // Navigate away from home
+    const projectsResp = waitForSpaHtmlFragmentResponse(page, 'projects.html');
     if (isMobile) {
       // On mobile, open sidebar and click Projects
       await page.locator('#mobile-menu-toggle').click();
@@ -135,6 +132,7 @@ test.describe('Navbar', () => {
       // Desktop: use navbar scoped selector to avoid mobile sidebar duplicates
       await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
     }
+    await projectsResp.catch(() => {});
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
       return c?.getAttribute('data-content-loaded') === 'true' || !!document.querySelector('#ProjInProgress .row, #ProjComplete .row');
@@ -168,6 +166,7 @@ test.describe('Navbar', () => {
     }
     
     // Click Home link
+    const homeResp = waitForSpaHtmlFragmentResponse(page, 'home.html');
     if (isMobile) {
       // On mobile, click RM brand or open sidebar and click Home
       await page.locator('.navbar-brand-name').click();
@@ -175,7 +174,8 @@ test.describe('Navbar', () => {
       // Desktop: use navbar scoped selector
       await page.locator('#navbar-links').getByRole('link', { name: 'Home' }).first().click();
     }
-    
+    await homeResp.catch(() => {});
+
     // Wait for content to load - use waitForFunction for better reliability on iPhone
     // Check for multiple possible indicators that home content has loaded
     await page.waitForFunction(() => {
@@ -212,8 +212,7 @@ test.describe('Navbar', () => {
   });
 
   test('Skills link navigates to skills page', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -274,8 +273,7 @@ test.describe('Navbar', () => {
   test('mobile sidebar opens and closes correctly', async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to load
@@ -311,8 +309,7 @@ test.describe('Navbar', () => {
   test('mobile sidebar navigation works', async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to load
@@ -368,8 +365,7 @@ test.describe('Navbar', () => {
   test('RM brand navigates to home on mobile', async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to load
@@ -412,8 +408,7 @@ test.describe('Navbar', () => {
   test('mobile sidebar footer has organized settings structure', async ({ page }) => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 667 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to load

--- a/tests/performance.spec.ts
+++ b/tests/performance.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil, tryWaitNetworkIdleBounded } from './nav-wait';
 
 test.describe('Performance', () => {
   test.describe.configure({ timeout: 120000 });
@@ -14,13 +15,10 @@ test.describe('Performance', () => {
 
   test('page loads within acceptable time', async ({ page }) => {
     const startTime = Date.now();
-    
-    // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    const gotoTimeout = browserName === 'firefox' ? 90000 : 60000;
-    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: gotoTimeout });
-    
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60_000 });
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready - check if content element exists
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -31,19 +29,16 @@ test.describe('Performance', () => {
     }, { timeout: 15000 });
 
     const loadTime = Date.now() - startTime;
-    
-    // Page should load within 5 seconds (Chromium) or 8 seconds (Firefox with networkidle)
-    const maxLoadTime = browserName === 'firefox' ? 8000 : 5000;
-    expect(loadTime).toBeLessThan(maxLoadTime);
+
+    // Same ceiling for all browsers (avoid networkidle on goto in CI; bounded idle wait above)
+    expect(loadTime).toBeLessThan(8000);
   });
 
   test('SPA navigation is fast', async ({ page }) => {
-    // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    const gotoTimeout = browserName === 'firefox' ? 90000 : 60000;
-    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: gotoTimeout });
-    
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60_000 });
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready - check if content element exists
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -78,10 +73,10 @@ test.describe('Performance', () => {
   });
 
   test('images are optimized', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready - check if content element exists
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -116,10 +111,10 @@ test.describe('Performance', () => {
       }
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready - check if content element exists
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -134,10 +129,10 @@ test.describe('Performance', () => {
   });
 
   test('page is interactive quickly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     const interactiveTime = await page.evaluate(() => {
       return new Promise((resolve) => {
         if (document.readyState === 'complete') {
@@ -155,10 +150,10 @@ test.describe('Performance', () => {
   });
 
   test('no memory leaks on navigation', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready - check if content element exists
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -195,10 +190,10 @@ test.describe('Performance', () => {
   });
 
   test('page performance metrics are acceptable', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
-    
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for page to be ready
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;
@@ -257,11 +252,10 @@ test.describe('Performance', () => {
       }
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    const gotoTimeout = browserName === 'firefox' ? 90000 : 60000;
-    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: gotoTimeout });
-    
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60_000 });
+    await tryWaitNetworkIdleBounded(page, 8000);
+
     // Wait for content
     await page.waitForFunction(() => {
       return document.querySelector('#content') !== null;

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Projects Page', () => {
   // Set timeout for all tests in this describe block
@@ -13,8 +14,7 @@ test.describe('Projects Page', () => {
   });
 
   test('navigates to Projects via navbar and renders content', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -138,8 +138,7 @@ test.describe('Projects Page', () => {
         body: JSON.stringify(mockProjects),
       });
     });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {
@@ -207,8 +206,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {
@@ -262,8 +260,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {
@@ -520,8 +517,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForSelector('#content', { state: 'attached', timeout: 15000 });
@@ -573,8 +569,7 @@ test.describe('Projects Page', () => {
 
   test('uses local API base when running on localhost', async ({ page }) => {
     test.skip(!!process.env.CI, 'In CI the app may load production api-config so API_BASE_URL is Render URL; only assert when running locally');
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => typeof (window as unknown as { API_BASE_URL?: string }).API_BASE_URL !== 'undefined', { timeout: 10000 });
@@ -593,8 +588,7 @@ test.describe('Projects Page', () => {
   });
 
   test('shows loading message in each section while projects load', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -648,8 +642,7 @@ test.describe('Projects Page', () => {
   test('projects reload correctly when navigating to page multiple times', async ({ page }) => {
     test.setTimeout(90000); // Increase timeout for this test (90 seconds)
     
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -753,8 +746,7 @@ test.describe('Projects Page', () => {
   });
 
   test('project icons are visible in dark mode', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -809,8 +801,7 @@ test.describe('Projects Page', () => {
   });
 
   test('projects page has correct title and subtitle', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -861,8 +852,7 @@ test.describe('Projects Page', () => {
 
   test('project cards have correct structure when loaded', async ({ page }) => {
     // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -920,8 +910,7 @@ test.describe('Projects Page', () => {
   });
 
   test('project sections exist (In Progress, Complete, Coming Soon)', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -980,8 +969,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForSelector('#content', { state: 'attached', timeout: 15000 });
@@ -1031,8 +1019,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', {
       waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
       timeout: 60000,
@@ -1122,8 +1109,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', {
       waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
       timeout: 60000,
@@ -1209,8 +1195,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForSelector('#content', { state: 'attached', timeout: 15000 });
@@ -1295,8 +1280,7 @@ test.describe('Projects Page', () => {
       });
     });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'domcontentloaded' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {

--- a/tests/responsive.spec.ts
+++ b/tests/responsive.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 const viewports = [
   { name: 'mobile', size: { width: 375, height: 812 } },
@@ -10,10 +11,11 @@ test.describe('Responsive layout', () => {
   for (const vp of viewports) {
     test(`home layout is cohesive on ${vp.name}`, async ({ page }) => {
       await page.setViewportSize(vp.size);
-      // Use networkidle for Firefox, domcontentloaded for others
-      const browserName = page.context().browser()?.browserType().name() || '';
-      const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-      await page.goto('/', { waitUntil, timeout: 90000 });
+      const waitUntil = spaGotoWaitUntil();
+      await page.goto('/', {
+        waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
+        timeout: 90_000,
+      });
 
       // Wait for content to load
       await page.waitForFunction(() => {
@@ -67,8 +69,7 @@ test.describe('Responsive layout', () => {
   
   test('hero banner stacks correctly on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     await page.waitForFunction(() => {
@@ -95,8 +96,7 @@ test.describe('Responsive layout', () => {
   
   test('stats cards stack vertically on mobile', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load
@@ -140,8 +140,7 @@ test.describe('Responsive layout', () => {
 
   test('mobile sidebar shows Blog links (Engineering, Personal)', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('SEO & Meta Tags', () => {
   test.describe.configure({ timeout: 120000 });
@@ -19,9 +20,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('home page has proper meta tags', async ({ page }) => {
-    // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to fully load
@@ -90,8 +89,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('page has Open Graph meta tags', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check for Open Graph tags (optional but recommended)
@@ -113,8 +111,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('page has canonical URL', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     await page.waitForFunction(() => {
@@ -137,8 +134,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('favicon is present', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check for favicon link
@@ -152,8 +148,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('structured data is present', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -178,8 +173,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('headings follow semantic structure', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -211,7 +205,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('links are crawlable', async ({ page }) => {
-    const waitUntil = 'domcontentloaded'; // networkidle often never fires in CI (Firefox)
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for page to be ready - check if content element exists
@@ -238,9 +232,7 @@ test.describe('SEO & Meta Tags', () => {
   });
 
   test('robots meta tag is configured', async ({ page }) => {
-    // Use networkidle for Firefox, domcontentloaded for others
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil, timeout: 90000 });
     
     // Check for robots meta tag

--- a/tests/spa-navigation.spec.ts
+++ b/tests/spa-navigation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil, waitForSpaHtmlFragmentResponse } from './nav-wait';
 
 test.describe('SPA Navigation', () => {
   // Set timeout for all tests in this describe block
@@ -13,8 +14,7 @@ test.describe('SPA Navigation', () => {
   });
 
   test('navigation loads content into #content without full page reload', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Initial page load - wait for content
@@ -34,6 +34,7 @@ test.describe('SPA Navigation', () => {
     const isMobile = await page.evaluate(() => window.innerWidth <= 768);
     
     // Navigate to Projects - handle mobile
+    const projectsResp = waitForSpaHtmlFragmentResponse(page, 'projects.html');
     if (isMobile) {
       await page.locator('#mobile-menu-toggle').click();
       await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
@@ -41,7 +42,8 @@ test.describe('SPA Navigation', () => {
     } else {
       await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
     }
-    
+    await projectsResp.catch(() => {});
+
     // Wait for projects page to load
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -83,8 +85,7 @@ test.describe('SPA Navigation', () => {
   });
 
   test('theme persists across SPA navigation', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -108,13 +109,15 @@ test.describe('SPA Navigation', () => {
     });
     
     // Navigate to different pages - handle mobile
+    const projectsResp = waitForSpaHtmlFragmentResponse(page, 'projects.html');
     if (isMobile) {
       // Sidebar should still be open
       await page.locator('.mobile-nav-item[data-url="html/pages/projects.html"]').click();
     } else {
       await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
     }
-    await page.waitForTimeout(1000);
+    await projectsResp.catch(() => {});
+    await page.waitForTimeout(500);
     
     let themeAfter = await page.evaluate(() => {
       return document.documentElement.getAttribute('data-theme');
@@ -122,6 +125,7 @@ test.describe('SPA Navigation', () => {
     expect(themeAfter).toBe(themeBefore);
     
     // Navigate to Skills - handle mobile
+    const skillsResp = waitForSpaHtmlFragmentResponse(page, 'skills.html');
     if (isMobile) {
       await page.locator('#mobile-menu-toggle').click();
       await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
@@ -129,7 +133,8 @@ test.describe('SPA Navigation', () => {
     } else {
       await page.locator('#navbar-links a[data-translate="nav.skills"]').first().click();
     }
-    await page.waitForTimeout(1000);
+    await skillsResp.catch(() => {});
+    await page.waitForTimeout(500);
     
     themeAfter = await page.evaluate(() => {
       return document.documentElement.getAttribute('data-theme');
@@ -138,8 +143,7 @@ test.describe('SPA Navigation', () => {
   });
 
   test('tutorials page does not reload entire page when clicked', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     const initialUrl = page.url();
@@ -148,6 +152,7 @@ test.describe('SPA Navigation', () => {
     const isMobile = await page.evaluate(() => window.innerWidth <= 768);
     
     // Click Tutorials - handle mobile (Docs dropdown on desktop)
+    const tutorialsResp = waitForSpaHtmlFragmentResponse(page, 'tutorials.html');
     if (isMobile) {
       await page.locator('#mobile-menu-toggle').click();
       await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
@@ -166,7 +171,8 @@ test.describe('SPA Navigation', () => {
       await docsButton.hover();
       await page.locator('.dropdown-menu').first().getByRole('link', { name: 'Tutorials' }).click();
     }
-    
+    await tutorialsResp.catch(() => {});
+
     // Wait for content to load - use waitForFunction for better reliability
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -208,8 +214,7 @@ test.describe('SPA Navigation', () => {
   });
 
   test('content does not duplicate on multiple navigations', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -224,6 +229,7 @@ test.describe('SPA Navigation', () => {
     
     // Navigate to Projects multiple times - handle mobile
     for (let i = 0; i < 3; i++) {
+      const projectsResp = waitForSpaHtmlFragmentResponse(page, 'projects.html');
       if (isMobile) {
         await page.locator('#mobile-menu-toggle').click();
         await page.waitForSelector('#mobile-sidebar.active', { timeout: 2000 });
@@ -231,7 +237,8 @@ test.describe('SPA Navigation', () => {
       } else {
         await page.locator('#navbar-links').getByRole('link', { name: 'Projects' }).first().click();
       }
-      
+      await projectsResp.catch(() => {});
+
       // Wait for projects page to load
       await page.waitForFunction(() => {
         const c = document.querySelector('#content');
@@ -262,8 +269,7 @@ test.describe('SPA Navigation', () => {
   });
 
   test('SPA navigation resets scroll to top', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
@@ -271,6 +277,7 @@ test.describe('SPA Navigation', () => {
     }, { timeout: 15000 });
 
     const isMobile = await page.evaluate(() => window.innerWidth <= 768);
+    const engineeringResp = waitForSpaHtmlFragmentResponse(page, 'engineering.html');
     if (isMobile) {
       await page.locator('#mobile-menu-toggle').click();
       await page.waitForSelector('#mobile-sidebar.active', { timeout: 5000 });
@@ -284,6 +291,7 @@ test.describe('SPA Navigation', () => {
       await blogButton.hover();
       await page.locator('.dropdown-menu-blog').first().getByRole('link', { name: 'Engineering' }).click();
     }
+    await engineeringResp.catch(() => {});
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
       return c?.getAttribute('data-content-loaded') === 'true' && !!c?.querySelector('.blog-featured');
@@ -298,6 +306,7 @@ test.describe('SPA Navigation', () => {
       expect(scrollAfterEngineering).toBe(0);
     }
 
+    const homeResp = waitForSpaHtmlFragmentResponse(page, 'home.html');
     if (isMobile) {
       await page.locator('#mobile-menu-toggle').click();
       await page.waitForSelector('#mobile-sidebar.active', { timeout: 5000 });
@@ -305,6 +314,7 @@ test.describe('SPA Navigation', () => {
     } else {
       await page.locator('#navbar-links').getByRole('link', { name: 'Home' }).first().click();
     }
+    await homeResp.catch(() => {});
     await page.waitForFunction(() => {
       const c = document.querySelector('#content');
       return c?.getAttribute('data-content-loaded') === 'true' && !!c?.querySelector('#homeBanner, .carousel');

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('Theme Toggle (Dark/Light Mode)', () => {
   test('theme toggle button is visible and functional', async ({ page }) => {
     // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Check if we're on mobile
@@ -47,8 +47,7 @@ test.describe('Theme Toggle (Dark/Light Mode)', () => {
 
   test('theme persists across page navigation', async ({ page }) => {
     // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Check if we're on mobile
@@ -90,8 +89,7 @@ test.describe('Theme Toggle (Dark/Light Mode)', () => {
 
   test('links are white in dark mode and black in light mode', async ({ page }) => {
     // Firefox needs networkidle instead of domcontentloaded for reliability
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit' });
     
     // Wait for content to load
@@ -152,8 +150,7 @@ test.describe('Theme Toggle (Dark/Light Mode)', () => {
   test('body background adapts to theme', async ({ page }) => {
     // For Firefox, use networkidle instead of domcontentloaded as it's more reliable
     // networkidle waits for network to be idle, which is better for SPA navigation
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     

--- a/tests/translation.spec.ts
+++ b/tests/translation.spec.ts
@@ -1,28 +1,9 @@
 import { test, expect } from '@playwright/test';
+import { gotoHomeReady } from './nav-wait';
 
 test.describe('Translation feature', () => {
   test.beforeEach(async ({ page }) => {
-    // Navigate with increased timeout for Firefox
-    try {
-      await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 45000 });
-    } catch (error) {
-      // If navigation times out, try again with networkidle
-      await page.goto('/', { waitUntil: 'networkidle', timeout: 60000 });
-    }
-    
-    // Wait for content element to be attached
-    // Wait for page to be ready - check if content element exists
-    await page.waitForFunction(() => {
-      return document.querySelector('#content') !== null;
-    }, { timeout: 30000 });
-    
-    // Wait for content to load
-    await page.waitForFunction(() => {
-      const c = document.querySelector('#content');
-      return c?.getAttribute('data-content-loaded') === 'true' || !!c?.querySelector('#homeBanner');
-    }, { timeout: 20000 });
-    
-    // Small delay to ensure everything is settled
+    await gotoHomeReady(page);
     await page.waitForTimeout(500);
   });
 

--- a/tests/tutorials.spec.ts
+++ b/tests/tutorials.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 async function navigateToTutorials(page: Page, isMobile: boolean) {
   if (isMobile) {
@@ -34,8 +35,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('tutorials page loads without redirecting entire page', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load
@@ -97,8 +97,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('tutorial cards display correctly with icons and links', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -160,8 +159,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('Python tutorial index page loads with lesson cards', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -196,8 +194,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('lesson pages load with back button and navigation', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -242,8 +239,7 @@ test.describe('Tutorials Page', () => {
     if (process.env.CI) {
       return;
     }
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -311,8 +307,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('lesson navigation links work correctly', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Check if we're on mobile
@@ -373,8 +368,7 @@ test.describe('Tutorials Page', () => {
   });
 
   test('tutorial page text and links are visible and clickable', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial load

--- a/tests/user-journey.spec.ts
+++ b/tests/user-journey.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 test.describe('[integration] End-to-End User Journeys', () => {
   test.describe.configure({ timeout: 180000 }); // 3 minutes for full journeys
-  // Firefox: use domcontentloaded for page.goto; networkidle often never fires in CI (see docs/Post-Mortem/ci-firefox-page-goto-networkidle-timeout.md).
 
   test('complete user journey: browse portfolio', async ({ page }) => {
-    // Start at home page - use domcontentloaded for all browsers (networkidle often never fires in CI for Firefox)
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for content to load
@@ -112,7 +111,7 @@ test.describe('[integration] End-to-End User Journeys', () => {
     });
 
     // domcontentloaded for all browsers (networkidle often never fires in CI for Firefox)
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial content
@@ -191,7 +190,7 @@ test.describe('[integration] End-to-End User Journeys', () => {
 
   test('complete user journey: language switching', async ({ page }) => {
     // domcontentloaded for all browsers (networkidle often never fires in CI for Firefox)
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial content
@@ -262,7 +261,7 @@ test.describe('[integration] End-to-End User Journeys', () => {
 
   test('complete user journey: theme switching and navigation', async ({ page }) => {
     // Use domcontentloaded for all browsers; networkidle often never fires in CI for Firefox
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial content
@@ -351,7 +350,7 @@ test.describe('[integration] End-to-End User Journeys', () => {
 
   test('complete user journey: view documentation', async ({ page }) => {
     // Use domcontentloaded for all browsers; networkidle often never fires in CI for Firefox
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial content
@@ -410,7 +409,7 @@ test.describe('[integration] End-to-End User Journeys', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     
     // Use domcontentloaded for all browsers; networkidle often never fires in CI for Firefox
-    const waitUntil = 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
     
     // Wait for initial content

--- a/tests/visual-regression.spec.ts
+++ b/tests/visual-regression.spec.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { test, expect, type Page, type TestInfo } from '@playwright/test';
+import { spaGotoWaitUntil } from './nav-wait';
 
 function readPngDimensions(filePath: string) {
   try {
@@ -71,11 +72,10 @@ test.describe('Visual Regression Tests', () => {
     await page.addInitScript(() => {
       localStorage.setItem('siteLanguage', 'en');
     });
-});
+  });
   test('home page matches visual baseline', async ({ page }) => {
     test.skip(!!process.env.CI, 'Full-page screenshot height differs on CI Linux vs baseline; run locally or update snapshots from CI');
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for content to load
@@ -97,11 +97,11 @@ test.describe('Visual Regression Tests', () => {
 
   test('home page hero section matches baseline', async ({ page }) => {
     test.skip(!!process.env.CI, 'Hero screenshot differs on CI Linux vs baseline; run locally or update snapshots from CI');
-    // Firefox needs networkidle for reliable navigation
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
-    const timeout = browserName === 'firefox' ? 60000 : 20000;
-    await page.goto('/', { waitUntil, timeout });
+    const waitUntil = spaGotoWaitUntil();
+    await page.goto('/', {
+      waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit',
+      timeout: 60_000,
+    });
 
     // Wait for content to load
     await page.waitForFunction(() => {
@@ -121,8 +121,7 @@ test.describe('Visual Regression Tests', () => {
   });
 
   test('navbar matches visual baseline', async ({ page }) => {
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Target only the top navbar (exclude #mobile-sidebar which is also a nav)
@@ -163,7 +162,7 @@ test.describe('Visual Regression Tests', () => {
       });
     });
 
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for initial content
@@ -265,7 +264,7 @@ test.describe('Visual Regression Tests', () => {
   });
 
   test('contact form matches visual baseline', async ({ page }) => {
-    const waitUntil = 'domcontentloaded'; // networkidle often never fires in CI (Firefox)
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for initial content
@@ -308,8 +307,7 @@ test.describe('Visual Regression Tests', () => {
 
   test('dark mode matches visual baseline', async ({ page }) => {
     test.skip(!!process.env.CI, 'Full-page dark screenshot height differs on CI Linux vs baseline; run locally or update snapshots from CI');
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for content to load
@@ -349,8 +347,7 @@ test.describe('Visual Regression Tests', () => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 812 }); // iPhone 13 Pro size
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for content to load
@@ -374,8 +371,7 @@ test.describe('Visual Regression Tests', () => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 812 });
 
-    const browserName = page.context().browser()?.browserType().name() || '';
-    const waitUntil = browserName === 'firefox' ? 'networkidle' : 'domcontentloaded';
+    const waitUntil = spaGotoWaitUntil();
     await page.goto('/', { waitUntil: waitUntil as 'load' | 'domcontentloaded' | 'networkidle' | 'commit', timeout: 60000 });
 
     // Wait for content to load


### PR DESCRIPTION
## Why this change

Firefox was timing out in CI on `page.goto(..., { waitUntil: 'networkidle' })` because this SPA often never reaches network idle in GitHub Actions. Chromium-iPhone had separate flakes when tests asserted DOM before the fragment response finished. This PR standardizes **deterministic** navigation and documents it with **Mermaid** where it helps.

## What changed

### Tests and helpers
- New `tests/nav-wait.ts`: `spaGotoWaitUntil()` (always `domcontentloaded` for `goto`), `gotoHomeReady()`, `waitForSpaHtmlFragmentResponse()` for response-then-DOM, and `tryWaitNetworkIdleBounded()` for optional quiet-network checks (e.g. performance specs).
- Migrated UI specs off the Firefox `networkidle` ternary on initial `goto`; added response waits where SPA navigations were high-risk (`spa-navigation`, `navbar`, etc.).
- `translation.spec.ts` `beforeEach` now uses `gotoHomeReady` (no `networkidle` retry fallback).

### Playwright config
- **CI retries:** 1 (local 0).
- **CI workers:** 1 to cut contention between browsers, the Spring Boot API, and static UI servers on `ubuntu-latest`.

### Docs
- **`docs/UI_TESTING.md`:** Accurate config bullets (127.0.0.1, timeouts, workers, retries), CI tier **flowchart**, and SPA wait strategy **flowchart**.
- **`docs/testing/README.md`** and **`docs/README.md`:** Small diagrams for PR gates and doc map.
- **Post-mortems:** Mermaid in Firefox and Chromium-iPhone writeups; **`ci-playwright-ui-timeouts.md`** gets an April 2026 follow-up pointing at `nav-wait` and superseding old `goto` + `networkidle` advice.
- **`docs/MERMAID.md`:** Note on fenced Mermaid in repo Markdown.
- **`docs/testing/blog.md`:** Sequence diagram for response-then-DOM on post loads.

## How to verify

```bash
npx playwright install --with-deps   # if browsers missing
npx playwright test --project=chromium --project=firefox --project=chromium-iphone
```

Or match CI subsets (sanity / regression) as in `.github/workflows/playwright.yml`.

---

*Personal note: I would rather ship one more diagram and one less 60s timeout in the Actions log than chase another “passes on PR, fails on master” ghost.*