### PR TITLE
docs(ci): clarify where Playwright parallel CI is configured

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ flowchart LR
 - **[API Testing](TESTING.md)** - Complete guide for testing the Spring Boot API
 - **[UI Testing](UI_TESTING.md)** - Complete guide for Playwright E2E tests
 - **[Testing Index](testing/README.md)** - Overview of all test documentation
+- **[CI Parallel Execution](testing/ci-parallel-execution.md)** - How workflow sharding and Playwright workers control CI parallel runs
 
 ### Test Types
 - **Blog Tests** (`tests/blog.spec.ts`) - Blog listing pages (Engineering, Personal), Featured Post, Latest Insights, navigation to post, post detail structure (banner, hero, body)

--- a/docs/UI_TESTING.md
+++ b/docs/UI_TESTING.md
@@ -87,6 +87,8 @@ There are two GitHub Actions workflows for testing:
 - Note: Does NOT run on pull requests to avoid duplicate test runs
 - Purpose: Run all tests and normalize locators if tests fail
 
+Need to tune CI parallelism (shards vs Playwright workers)? See [CI Parallel Execution](testing/ci-parallel-execution.md).
+
 Per-job steps (simplified): checkout, setup Node/Java, install deps, (sanity: no browsers; full-suite: install Playwright browsers), build/start API (and UI for full-suite), run tests, upload artifacts (reports, traces, screenshots).
 
 ```mermaid

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -146,6 +146,7 @@ Playwright tests use a **tiered strategy** so master stays the source of truth (
 Merge is only allowed when sanity and all full-suite shards have passed on the PR, so master is not broken by a merge.
 
 See [UI Testing Guide](../UI_TESTING.md#cicd-integration) for skip keywords and artifact details.
+For shard/workers setup and tuning, see [CI Parallel Execution](ci-parallel-execution.md).
 
 ```mermaid
 flowchart LR

--- a/docs/testing/ci-parallel-execution.md
+++ b/docs/testing/ci-parallel-execution.md
@@ -1,0 +1,98 @@
+# CI Parallel Execution (Playwright)
+
+This guide explains where CI parallelism is configured for Playwright in this repository and how to tune it safely.
+
+## Where Parallelism Is Configured
+
+CI parallel execution comes from two layers:
+
+1. **Workflow-level sharding** in `.github/workflows/playwright.yml` (multiple jobs run at once).
+2. **Playwright runner settings** in `playwright.config.ts` (how each job runs tests internally).
+
+If you only change `playwright.config.ts`, you are not changing the number of parallel CI jobs. That fan-out is controlled by the workflow matrix.
+
+## Layer 1: Workflow Sharding (Main CI Fan-Out)
+
+In `.github/workflows/playwright.yml`, the `full-suite` job uses a matrix:
+
+- `shardIndex: [1, 2, 3, 4, 5]`
+- `shardTotal: [5]`
+
+Each matrix job runs:
+
+```bash
+npx playwright test ... --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+```
+
+This is what creates 5 parallel CI executions for the full suite.
+
+## Layer 2: Playwright Runner Parallelism (Inside Each Shard)
+
+In `playwright.config.ts`, key settings are:
+
+- `workers: process.env.CI ? 1 : undefined`
+- `fullyParallel: true`
+- `projects` list (`chromium`, `chromium-iphone`, `firefox`, `api`)
+
+What this means in CI today:
+
+- Each shard is a separate CI job (from workflow matrix).
+- Inside each shard, worker count is intentionally limited to `1` for stability.
+- Tests are still distributed by shard and project selection, so CI remains parallel overall.
+
+## Current Repository Setup
+
+- Full-suite runs as **5 shards in parallel** on PRs (and on `master` runs).
+- CI uses **1 worker per shard** (`workers: 1`) to reduce resource contention.
+- `fullyParallel: true` remains enabled for local and non-CI behavior and for compatibility with current suite structure.
+
+## How To Change Parallel CI Safely
+
+### Increase or decrease number of CI shards
+
+Edit `.github/workflows/playwright.yml`:
+
+- Change `matrix.shardIndex` values.
+- Keep `shardTotal` aligned with shard count.
+- Keep `--shard=i/n` using the same total.
+
+Example: move from 5 to 3 shards
+
+- `shardIndex: [1, 2, 3]`
+- `shardTotal: [3]`
+
+### Change per-shard worker concurrency
+
+Edit `playwright.config.ts`:
+
+- Update `workers: process.env.CI ? 1 : undefined` to desired CI value.
+
+Only raise CI workers if runners have enough CPU/RAM and test stability remains good.
+
+### Optional: tune browser/project spread
+
+The workflow assembles project flags (for UI/API) before running Playwright. If needed, tune project selection in `.github/workflows/playwright.yml` (`steps.skip-check.outputs.projects`) to reduce load.
+
+## Verification Checklist
+
+After changing parallel settings:
+
+1. Open a PR and confirm the number of `Full suite (shard i/n)` jobs matches your matrix.
+2. Confirm each shard command uses the expected `--shard=i/n`.
+3. Compare total runtime and flaky failures across at least 2-3 PR runs.
+4. Review uploaded artifacts (`playwright-report-shard-*`, `test-results-shard-*`) for failed shards.
+
+## Common Misconceptions
+
+- **"Parallel CI is set only in Playwright config."**  
+  Not in this repo. Most CI parallel fan-out comes from workflow matrix sharding.
+- **"`workers: 1` means CI is not parallel."**  
+  CI can still be highly parallel because multiple shard jobs run simultaneously.
+- **"More workers always means faster."**  
+  On constrained CI runners, higher workers can increase flakiness and total retries.
+
+## Quick Decision Guide
+
+- Want **more/fewer CI jobs**? Change workflow matrix shard count.
+- Want **more/fewer tests at once inside each job**? Change Playwright `workers`.
+- Seeing flaky timeouts or resource contention? Keep/increase sharding, but keep CI `workers` conservative.


### PR DESCRIPTION
## Why this PR
I wanted CI parallelism setup to be obvious at a glance. It was easy to assume everything lived in `playwright.config.ts`, while the main fan-out is actually driven by workflow sharding.

## What changed
- Added `docs/testing/ci-parallel-execution.md` as a focused guide for CI parallel execution.
- Explained the two layers clearly:
  - workflow-level sharding in `.github/workflows/playwright.yml`
  - in-job Playwright settings in `playwright.config.ts` (`workers`, `fullyParallel`, `projects`)
- Added tuning and verification guidance (how to change shard count vs worker count safely).
- Added discoverability links from:
  - `docs/UI_TESTING.md`
  - `docs/testing/README.md`
  - `docs/README.md`

## Validation
- Documentation-only changes.
- Added references in existing testing docs so contributors can find the guide quickly.

## Impact
- Faster onboarding for CI test tuning.
- Fewer configuration mistakes when adjusting Playwright parallel execution.